### PR TITLE
Fix pio initialization code

### DIFF
--- a/src/motors.h
+++ b/src/motors.h
@@ -5,6 +5,7 @@
 #include <FreeRTOS.h>
 #include <queue.h>
 
+#include "hardware/pio.h"
 #include "http_rest.h"
 
 #define EEPROM_MOTOR_DATA_REV                     5              // 16 byte 
@@ -63,6 +64,7 @@ typedef struct {
 
     // Set at run time
     void * tmc_driver;
+    PIO pio;
     int pio_sm;
     uint pio_program_offset;
 

--- a/src/ws2812.pio
+++ b/src/ws2812.pio
@@ -3,13 +3,18 @@
 ;
 ; SPDX-License-Identifier: BSD-3-Clause
 ;
+.pio_version 0 // only requires PIO version 0
 
 .program ws2812
 .side_set 1
 
-.define public T1 2
-.define public T2 5
-.define public T3 3
+; The following constants are selected for broad compatibility with WS2812,
+; WS2812B, and SK6812 LEDs. Other constants may support higher bandwidths for
+; specific LEDs, such as (7,10,8) for WS2812B LEDs.
+
+.define public T1 3
+.define public T2 3
+.define public T3 4
 
 .lang_opt python sideset_init = pico.PIO.OUT_HIGH
 .lang_opt python out_init     = pico.PIO.OUT_HIGH
@@ -49,9 +54,9 @@ static inline void ws2812_program_init(PIO pio, uint sm, uint offset, uint pin, 
 
 .program ws2812_parallel
 
-.define public T1 2
-.define public T2 5
-.define public T3 3
+.define public T1 3
+.define public T2 3
+.define public T3 4
 
 .wrap_target
     out x, 32
@@ -72,7 +77,6 @@ static inline void ws2812_parallel_program_init(PIO pio, uint sm, uint offset, u
     pio_sm_config c = ws2812_parallel_program_get_default_config(offset);
     sm_config_set_out_shift(&c, true, true, 32);
     sm_config_set_out_pins(&c, pin_base, pin_count);
-    sm_config_set_set_pins(&c, pin_base, pin_count);
     sm_config_set_fifo_join(&c, PIO_FIFO_JOIN_TX);
 
     int cycles_per_bit = ws2812_parallel_T1 + ws2812_parallel_T2 + ws2812_parallel_T3;

--- a/targets/raspberrypi_pico_w_config.h
+++ b/targets/raspberrypi_pico_w_config.h
@@ -41,8 +41,6 @@
 #define SCALE_UART_TX 0
 #define SCALE_UART_RX 1
 
-#define MOTOR_STEPPER_PIO pio1
-
 #define EEPROM_I2C i2c1
 #define EEPROM_SDA_PIN 10
 #define EEPROM_SCL_PIN 11


### PR DESCRIPTION
PIO initilization code is updated since SDK 2.0. The corresponding code for WS2812 and stepper driver is updated to fix RP2040 PIO issue. 

Reference: https://github.com/raspberrypi/pico-examples/blob/master/pio/ws2812/ws2812.c