### PR TITLE
Mirror PWM3 output from LED1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,8 +18,6 @@
     },
     "cmake.buildBeforeRun": true,
     "cmake.configureOnOpen": true,
-    "files.associations": {
-    },
     "cmake.configureSettings": {
         "CMAKE_BUILD_TYPE": "Debug",
         "PICO_BOARD": "pico2_w"  // or pico_w for RP2040 target

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,12 +6,14 @@
             "type": "process",
             "command": "openocd",
             "args": [
+            "-s",
+            "${env:OPENOCD_SCRIPTS}",
             "-f",
             "interface/cmsis-dap.cfg",
             "-f",
             "target/rp2040.cfg",
             "-c",
-            "adapter speed 1000; program {${command:cmake.launchTargetPath}} verify reset exit"
+            "adapter speed 5000; program {${command:cmake.launchTargetPath}} verify reset exit"
             ],
             "problemMatcher": []
         },
@@ -20,12 +22,14 @@
             "type": "process",
             "command": "openocd",
             "args": [
+            "-s",
+            "${env:OPENOCD_SCRIPTS}",
             "-f",
             "interface/cmsis-dap.cfg",
             "-f",
             "target/rp2350.cfg",
             "-c",
-            "adapter speed 1000; program {${command:cmake.launchTargetPath}} verify reset exit"
+            "adapter speed 5000; program {${command:cmake.launchTargetPath}} verify reset exit"
             ],
             "problemMatcher": []
         },

--- a/src/charge_mode.cpp
+++ b/src/charge_mode.cpp
@@ -469,9 +469,6 @@ void charge_mode_wait_for_cup_return() {
 
 
 uint8_t charge_mode_menu(bool charge_mode_skip_user_input) {
-    // Reset LED to default colour
-    neopixel_led_set_colour(NEOPIXEL_LED_DEFAULT_COLOUR, NEOPIXEL_LED_DEFAULT_COLOUR, NEOPIXEL_LED_DEFAULT_COLOUR, true);
-
     // Create target weight, if the charge mode weight is built by charge_weight_digits
     if (!charge_mode_skip_user_input) {
         switch (charge_mode_config.eeprom_charge_mode_data.decimal_places) {

--- a/src/common.h
+++ b/src/common.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 #include <FreeRTOS.h>
+#include "hardware/pio.h"
+
 
 typedef enum {
     DP_2 = 0,
@@ -16,6 +18,11 @@ extern "C" {
 
 // "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n"
 extern const char * http_json_header;
+
+typedef struct {
+    PIO pio;
+    int sm;
+} pio_config_t;
 
 
 /**

--- a/src/html/web_portal.html
+++ b/src/html/web_portal.html
@@ -526,7 +526,6 @@
                                 <input type="color" class="input w-full" name="l2">
                             </div>
 
-                            
                             <div class="grid grid-cols-2 gap-1">
                                 <span class="label-text">PWM3 Chain Count</span>
                                 <select class="select select-bordered" name="l3">
@@ -535,6 +534,13 @@
                                 </select>
                             </div>
 
+                            <div class="grid grid-cols-1 gap-1">
+                                <span class="label-text">Is RGBW LED? (WS2812B or SK6812)</span>
+                                <select class="select select-bordered" name="l4">
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
+                            </div>
 
                             <button class="btn btn-neutral settings-apply-btn">Apply</button>
                         </form>

--- a/src/html/web_portal.html
+++ b/src/html/web_portal.html
@@ -526,6 +526,16 @@
                                 <input type="color" class="input w-full" name="l2">
                             </div>
 
+                            
+                            <div class="grid grid-cols-2 gap-1">
+                                <span class="label-text">PWM3 Chain Count</span>
+                                <select class="select select-bordered" name="l3">
+                                    <option value="1">1</option>
+                                    <option value="2">2</option>
+                                </select>
+                            </div>
+
+
                             <button class="btn btn-neutral settings-apply-btn">Apply</button>
                         </form>
                     </section>

--- a/src/mini_12864_module.cpp
+++ b/src/mini_12864_module.cpp
@@ -338,7 +338,7 @@ uint8_t u8x8_byte_pico_hw_spi(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *
     {
         case U8X8_MSG_BYTE_SEND:
             // taskENTER_CRITICAL();
-            spi_write_blocking(DISPlAY0_SPI, (uint8_t *) arg_ptr, arg_int);
+            spi_write_blocking(DISPLAY0_SPI, (uint8_t *) arg_ptr, arg_int);
             // taskEXIT_CRITICAL();
             break;
         case U8X8_MSG_BYTE_INIT:

--- a/src/mini_12864_module.cpp
+++ b/src/mini_12864_module.cpp
@@ -367,7 +367,7 @@ void display_init() {
     // Configure 12864
     printf("Initializing Display Task -- ");
     // Initialize SPI engine
-    spi_init(DISPlAY0_SPI, 4000 * 1000);
+    spi_init(DISPLAY0_SPI, 4000 * 1000);
 
     // Configure port for SPI
     // gpio_set_function(DISPLAY0_RX_PIN, GPIO_FUNC_SPI);  // Rx

--- a/src/motors.c
+++ b/src/motors.c
@@ -305,14 +305,14 @@ bool driver_pio_init(motor_config_t * motor_config) {
         return false;
     }
 
-    motor_config->pio = pio;
-    motor_config->pio_sm = sm;
-    motor_config->pio_program_offset = offset;
-    stepper_program_init(motor_config->pio, 
-                         motor_config->pio_sm, 
-                         motor_config->pio_program_offset, motor_config->step_pin);
+    stepper_program_init(pio, sm, offset, motor_config->step_pin);
+
     // Start stepper state machine
-    pio_sm_set_enabled(motor_config->pio, motor_config->pio_sm, true);
+    pio_sm_set_enabled(pio, sm, true);
+
+    // Record the PIO configuration
+    motor_config->pio_config.pio = pio;
+    motor_config->pio_config.sm = sm;
 
     return true;
 }
@@ -407,13 +407,13 @@ void speed_ramp(motor_config_t * motor_config, float prev_speed, float new_speed
 
         current_speed = prev_speed + dv * percentage;
         current_period = speed_to_period(current_speed, pio_speed, full_rotation_steps);
-        pio_sm_clear_fifos(motor_config->pio, motor_config->pio_sm);
-        pio_sm_put(motor_config->pio, motor_config->pio_sm, current_period);
+        pio_sm_clear_fifos(motor_config->pio_config.pio, motor_config->pio_config.sm);
+        pio_sm_put(motor_config->pio_config.pio, motor_config->pio_config.sm, current_period);
     }
 
     current_period = speed_to_period(new_speed, pio_speed, full_rotation_steps);
-    pio_sm_clear_fifos(motor_config->pio, motor_config->pio_sm);
-    pio_sm_put_blocking(motor_config->pio, motor_config->pio_sm, current_period);
+    pio_sm_clear_fifos(motor_config->pio_config.pio, motor_config->pio_config.sm);
+    pio_sm_put_blocking(motor_config->pio_config.pio, motor_config->pio_config.sm, current_period);
 }
 
 

--- a/src/motors.h
+++ b/src/motors.h
@@ -5,7 +5,7 @@
 #include <FreeRTOS.h>
 #include <queue.h>
 
-#include "hardware/pio.h"
+#include "common.h"
 #include "http_rest.h"
 
 #define EEPROM_MOTOR_DATA_REV                     5              // 16 byte 
@@ -64,9 +64,7 @@ typedef struct {
 
     // Set at run time
     void * tmc_driver;
-    PIO pio;
-    int pio_sm;
-    uint pio_program_offset;
+    pio_config_t pio_config;
 
     // Used to store some live data
     float prev_velocity;

--- a/src/neopixel_led.c
+++ b/src/neopixel_led.c
@@ -32,15 +32,24 @@
 #include "common.h"
 
 
+/* Configuration file for neopixel LEDs on both mini12864 display (including three LEDs in chain) and one dedicated LED on PWM3
+   PWM3 output will mirror the LED1 colour from mini12864 display.
+*/
 typedef struct {
     eeprom_neopixel_led_metadata_t eeprom_neopixel_led_metadata;
 
     neopixel_led_colours_t current_led_colours;
     xQueueHandle colour_update_queue;
     TaskHandle_t neopixel_control_task_handler;
-    PIO pio;
-    int pio_sm;
+    pio_config_t mini12864_pio_config;
+    pio_config_t pwm3_pio_config;
 } neopixel_led_config_t;
+
+// The parameters for updating the NeoPixel LED colors (including the target LED information)
+typedef struct {
+    pio_config_t * pio_config;
+    uint32_t colour;
+} _neopixel_led_colour_update_params_t;
 
 
 static neopixel_led_config_t neopixel_led_config;
@@ -53,72 +62,78 @@ uint32_t urgb_u32(uint8_t r, uint8_t g, uint8_t b) {
             (uint32_t) (b);
 }
  
-static inline void put_pixel(uint32_t pixel_grb) {
-    pio_sm_put_blocking(neopixel_led_config.pio, neopixel_led_config.pio_sm, pixel_grb << 8u);
+static inline void put_pixel(pio_config_t * pio_config, uint32_t pixel_grb) {
+    pio_sm_put_blocking(pio_config->pio, pio_config->sm, pixel_grb << 8u);
 }
 
 
+// Low level function to bypass RTOS to configure colour directly
+void _neopixel_led_set_colour(uint32_t led1_colour, uint32_t led2_colour, uint32_t mini12864_backlight_colour) {
+    put_pixel(&neopixel_led_config.mini12864_pio_config, led1_colour);  // Encoder RGB1
+    put_pixel(&neopixel_led_config.mini12864_pio_config, led2_colour);  // Encoder RGB2
+    put_pixel(&neopixel_led_config.mini12864_pio_config, mini12864_backlight_colour);  // 12864 Backlight
+}
+
+
+
 void neopixel_led_set_colour(uint32_t mini12864_backlight_colour, uint32_t led1_colour, uint32_t led2_colour, bool block_wait) {
-    neopixel_led_colours_t new_colours;
-
-    if (mini12864_backlight_colour == NEOPIXEL_LED_NO_CHANGE) {
-        new_colours.mini12864_backlight_colour = neopixel_led_config.current_led_colours.mini12864_backlight_colour;
-    }
-    else if (mini12864_backlight_colour == NEOPIXEL_LED_DEFAULT_COLOUR) {
-        new_colours.mini12864_backlight_colour = neopixel_led_config.eeprom_neopixel_led_metadata.default_led_colours.mini12864_backlight_colour;
-    }
-    else {
-        new_colours.mini12864_backlight_colour = mini12864_backlight_colour;
-    }
-
-    if (led1_colour == NEOPIXEL_LED_NO_CHANGE) {
-        new_colours.led1_colour = neopixel_led_config.current_led_colours.led1_colour;
-
-    }
-    else if (led1_colour == NEOPIXEL_LED_DEFAULT_COLOUR) {
-        new_colours.led1_colour = neopixel_led_config.eeprom_neopixel_led_metadata.default_led_colours.led1_colour;
-    }
-    else {
-        new_colours.led1_colour = led1_colour;
-    }
-
-    if (led2_colour == NEOPIXEL_LED_NO_CHANGE) {
-        new_colours.led2_colour = neopixel_led_config.current_led_colours.led2_colour;
-    }
-    else if (led1_colour == NEOPIXEL_LED_DEFAULT_COLOUR) {
-        new_colours.led2_colour = neopixel_led_config.eeprom_neopixel_led_metadata.default_led_colours.led2_colour;
-    }
-    else {
-        new_colours.led2_colour = led2_colour;
-    }
-
+    // Assign delay time
     TickType_t ticks_to_wait = 0;
     if (block_wait) {
         ticks_to_wait = portMAX_DELAY;
     }
 
-    xQueueSend(neopixel_led_config.colour_update_queue, &new_colours, ticks_to_wait);
-}
+    _neopixel_led_colour_update_params_t update_params;
+    update_params.pio_config = &neopixel_led_config.mini12864_pio_config;
+
+    /* Important: do not change the order of LED update operations. 
+       Neopixel LEDs on the same string are updated in the order they are sent. The update order has to be: 
+        1. Encoder RGB1
+        2. Encoder RGB2
+        3. 12864 Backlight
+    */
+    if (led1_colour == NEOPIXEL_LED_NO_CHANGE) {
+        update_params.colour = neopixel_led_config.current_led_colours.led1_colour;
+
+    }
+    else if (led1_colour == NEOPIXEL_LED_DEFAULT_COLOUR) {
+        update_params.colour = neopixel_led_config.eeprom_neopixel_led_metadata.default_led_colours.led1_colour;
+    }
+    else {
+        update_params.colour = led1_colour;
+    }
+    xQueueSend(neopixel_led_config.colour_update_queue, &update_params, ticks_to_wait);
 
 
-void _neopixel_led_set_colour(uint32_t led1_colour, uint32_t led2_colour, uint32_t mini12864_backlight_colour) {
-    put_pixel(led1_colour);  // Encoder RGB1
-    put_pixel(led2_colour);  // Encoder RGB2
-    put_pixel(mini12864_backlight_colour);  // 12864 Backlight
+    if (led2_colour == NEOPIXEL_LED_NO_CHANGE) {
+        update_params.colour = neopixel_led_config.current_led_colours.led2_colour;
+    }
+    else if (led2_colour == NEOPIXEL_LED_DEFAULT_COLOUR) {
+        update_params.colour = neopixel_led_config.eeprom_neopixel_led_metadata.default_led_colours.led2_colour;
+    }
+    else {
+        update_params.colour = led2_colour;
+    }
+    xQueueSend(neopixel_led_config.colour_update_queue, &update_params, ticks_to_wait);
+
+    if (mini12864_backlight_colour == NEOPIXEL_LED_NO_CHANGE) {
+        update_params.colour = neopixel_led_config.current_led_colours.mini12864_backlight_colour;
+    }
+    else if (mini12864_backlight_colour == NEOPIXEL_LED_DEFAULT_COLOUR) {
+        update_params.colour = neopixel_led_config.eeprom_neopixel_led_metadata.default_led_colours.mini12864_backlight_colour;
+    }
+    else {
+        update_params.colour = mini12864_backlight_colour;
+    }
+    xQueueSend(neopixel_led_config.colour_update_queue, &update_params, ticks_to_wait);
 }
 
 
 void neopixel_control_task(void *p) {
     while (true) {
-        neopixel_led_colours_t new_colours;
-        xQueueReceive(neopixel_led_config.colour_update_queue, &new_colours, portMAX_DELAY);
-
-        // Apply
-        _neopixel_led_set_colour(
-            new_colours.led1_colour,
-            new_colours.led2_colour,
-            new_colours.mini12864_backlight_colour
-        );
+        _neopixel_led_colour_update_params_t update_params;
+        xQueueReceive(neopixel_led_config.colour_update_queue, &update_params, portMAX_DELAY);
+        put_pixel(update_params.pio_config, update_params.colour);
     }
 }
 
@@ -159,31 +174,46 @@ bool neopixel_led_init(void) {
     neopixel_led_config.colour_update_queue = xQueueCreate(2, sizeof(neopixel_led_colours_t));
     assert(neopixel_led_config.colour_update_queue);
 
-    // Configure Neopixel (WS2812) with PIO
+    // Configure Neopixel for mini12864 display
     PIO pio;
-    uint ws2812_sm;
-    uint ws2812_offset;
+    uint sm;
+    uint offset;
 
     is_ok = pio_claim_free_sm_and_add_program_for_gpio_range(
-        &ws2812_program, &pio, &ws2812_sm, &ws2812_offset, NEOPIXEL_PIN, 1, true
+        &ws2812_program, &pio, &sm, &offset, NEOPIXEL_PIN, 1, true
     );
     if (!is_ok) {
-        printf("Unable to initialize WS2812 PIO");
+        printf("Unable to initialize mini12864 Neopixel PIO");
         return false;
     }
 
-    ws2812_program_init(pio, ws2812_sm, ws2812_offset, NEOPIXEL_PIN, 800000, false);
+    ws2812_program_init(pio, sm, offset, NEOPIXEL_PIN, 800000, false);
 
     // Save pio and sm for later access
-    neopixel_led_config.pio = pio;
-    neopixel_led_config.pio_sm = ws2812_sm;
+    neopixel_led_config.mini12864_pio_config.pio = pio;
+    neopixel_led_config.mini12864_pio_config.sm = sm;
 
     // Set default colour
-    _neopixel_led_set_colour(
-        neopixel_led_config.current_led_colours.led1_colour,
-        neopixel_led_config.current_led_colours.led2_colour,
-        neopixel_led_config.current_led_colours.mini12864_backlight_colour
+    put_pixel(&neopixel_led_config.mini12864_pio_config, neopixel_led_config.current_led_colours.led1_colour);  // Encoder RGB1
+    put_pixel(&neopixel_led_config.mini12864_pio_config, neopixel_led_config.current_led_colours.led2_colour);  // Encoder RGB2
+    put_pixel(&neopixel_led_config.mini12864_pio_config, neopixel_led_config.current_led_colours.mini12864_backlight_colour);  // 12864 Backlight
+
+    // Configure Neopixel for PWM3
+    is_ok = pio_claim_free_sm_and_add_program_for_gpio_range(
+        &ws2812_program, &pio, &sm, &offset, NEOPIXEL_PWM3_PIN, 1, true
     );
+    if (!is_ok) {
+        printf("Unable to initialize PWM3 Neopixel PIO");
+        return false;
+    }
+
+    ws2812_program_init(pio, sm, offset, NEOPIXEL_PWM3_PIN, 800000, false);
+    
+    // Save pio and sm for later access
+    neopixel_led_config.pwm3_pio_config.pio = pio;
+    neopixel_led_config.pwm3_pio_config.sm = sm;
+    // Set default colour for PWM3
+    put_pixel(&neopixel_led_config.pwm3_pio_config, neopixel_led_config.current_led_colours.led1_colour);
 
     // Initialize the task
     xTaskCreate(neopixel_control_task, 

--- a/src/neopixel_led.h
+++ b/src/neopixel_led.h
@@ -27,6 +27,7 @@ typedef struct {
     uint16_t neopixel_data_rev;
     neopixel_led_colours_t default_led_colours;
     neopixel_led_chain_count_t pwm3_led_chain_count;
+    bool is_rgbw;   // true: RGBW, false: RGB
 } eeprom_neopixel_led_metadata_t;
 
 

--- a/src/neopixel_led.h
+++ b/src/neopixel_led.h
@@ -5,7 +5,7 @@
 #include "http_rest.h"
 
 
-#define EEPROM_NEOPIXEL_LED_METADATA_REV                     2              // 16 byte 
+#define EEPROM_NEOPIXEL_LED_METADATA_REV                     3              // 16 byte 
 
 #define NEOPIXEL_LED_NO_CHANGE      (uint32_t)(1 << 24)                     // High bit is not used for Neopixel RGB
 #define NEOPIXEL_LED_DEFAULT_COLOUR (uint32_t)(1 << 25)
@@ -17,10 +17,16 @@ typedef struct {
     uint32_t mini12864_backlight_colour;
 } neopixel_led_colours_t;
 
+typedef enum {
+    NEOPIXEL_LED_CHAIN_COUNT_1 = 1,  // 1 LED from the same chain
+    NEOPIXEL_LED_CHAIN_COUNT_2 = 2,  // 2 LEDs from the same chain
+} neopixel_led_chain_count_t;
+
 
 typedef struct {
     uint16_t neopixel_data_rev;
     neopixel_led_colours_t default_led_colours;
+    neopixel_led_chain_count_t pwm3_led_chain_count;
 } eeprom_neopixel_led_metadata_t;
 
 

--- a/targets/raspberrypi_pico_w_config.h
+++ b/targets/raspberrypi_pico_w_config.h
@@ -8,7 +8,7 @@
 // Settings
 #define WATCHDOG_LED_PIN CYW43_WL_GPIO_LED_PIN
 
-#define DISPlAY0_SPI spi0
+#define DISPLAY0_SPI spi0
 #define DISPLAY0_RX_PIN 16
 #define DISPLAY0_TX_PIN 19
 #define DISPLAY0_CS_PIN 17

--- a/targets/raspberrypi_pico_w_config.h
+++ b/targets/raspberrypi_pico_w_config.h
@@ -3,9 +3,10 @@
 
 #include "pico/cyw43_arch.h"
 
+/* Specify board PIN mapping
+    Reference: https://github.com/eamars/RaspberryPi-Pico-Motor-Expansion-Board?tab=readme-ov-file#peripherals
+*/
 
-
-// Settings
 #define WATCHDOG_LED_PIN CYW43_WL_GPIO_LED_PIN
 
 #define DISPLAY0_SPI spi0
@@ -21,6 +22,7 @@
 #define BUTTON0_ENC_PIN 22
 #define BUTTON0_RST_PIN 12
 #define NEOPIXEL_PIN 13
+#define NEOPIXEL_2_PIN 28
 
 #define MOTOR_UART uart1
 #define MOTOR_UART_TX 4

--- a/targets/raspberrypi_pico_w_config.h
+++ b/targets/raspberrypi_pico_w_config.h
@@ -22,7 +22,7 @@
 #define BUTTON0_ENC_PIN 22
 #define BUTTON0_RST_PIN 12
 #define NEOPIXEL_PIN 13
-#define NEOPIXEL_2_PIN 28
+#define NEOPIXEL_PWM3_PIN 28
 
 #define MOTOR_UART uart1
 #define MOTOR_UART_TX 4


### PR DESCRIPTION
Mirroring the LED output state of the rotary encoder to the PWM3 output from the motor controller board, allowing the dedicated neopixel LED to be installed. 
<img width="599" height="436" alt="image" src="https://github.com/user-attachments/assets/400a2ad2-c2bd-4e91-85e0-b6f683c60651" />
