### PR TITLE
Add a fixed delay before precharge

### DIFF
--- a/src/charge_mode.cpp
+++ b/src/charge_mode.cpp
@@ -322,6 +322,10 @@ void charge_mode_wait_for_complete() {
 
     // Precharge
     if (charge_mode_config.eeprom_charge_mode_data.precharge_enable && servo_gate.gate_state != GATE_DISABLED) {
+        // Set a fixed delay between closing the gate and precharge to allow the gate to fully close
+        vTaskDelay(pdMS_TO_TICKS(500));
+
+        // Start the pre-charge
         motor_set_speed(SELECT_COARSE_TRICKLER_MOTOR, charge_mode_config.eeprom_charge_mode_data.precharge_speed_rps);
         vTaskDelay(pdMS_TO_TICKS(charge_mode_config.eeprom_charge_mode_data.precharge_time_ms));
 


### PR DESCRIPTION
Add a fixed delay between servo gate close and the starting of the motor to to ensure the gate is fully closed prior to the pre charge. 