### PR TITLE
see my readme for what i addedFix include guard typo and remove duplicate includes

### DIFF
--- a/src/and_scale.c
+++ b/src/and_scale.c
@@ -5,7 +5,6 @@
 #include <time.h>
 #include <math.h>
 #include <task.h>
-#include <stdlib.h>
 
 #include "hardware/uart.h"
 #include "configuration.h"

--- a/src/cleanup_mode.h
+++ b/src/cleanup_mode.h
@@ -1,5 +1,5 @@
 #ifndef CLEANUP_MODE_H_
-#define CLENAUP_MODE_H_
+#define CLEANUP_MODE_H_
 
 #include <stdint.h>
 #include "http_rest.h"

--- a/src/creedmoor_scale.c
+++ b/src/creedmoor_scale.c
@@ -5,7 +5,6 @@
 #include <time.h>
 #include <math.h>
 #include <task.h>
-#include <stdlib.h>
 
 #include "hardware/uart.h"
 #include "configuration.h"

--- a/src/gng_scale.c
+++ b/src/gng_scale.c
@@ -5,7 +5,6 @@
 #include <time.h>
 #include <math.h>
 #include <task.h>
-#include <stdlib.h>
 
 #include "hardware/uart.h"
 #include "configuration.h"

--- a/src/motors.c
+++ b/src/motors.c
@@ -4,7 +4,6 @@
 #include <math.h>
 #include <FreeRTOS.h>
 #include <queue.h>
-#include <math.h>
 #include "app.h"
 #include "tmc2209.h"
 #include "hardware/uart.h"


### PR DESCRIPTION
- Fix typo in cleanup_mode.h (CLENAUP -> CLEANUP)
- Remove duplicate #include <stdlib.h> in and_scale.c, creedmoor_scale.c, gng_scale.c
- Remove duplicate #include <math.h> in motors.c