### PR TITLE
Add OTA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ CTestTestfile.cmake
 _deps
 
 # VSCode stuff
+.vs/*
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json
@@ -80,3 +81,10 @@ _deps
 
 # Build directory
 build*/
+
+# Python virtual environment
+venv/
+__pycache__/
+
+#Claude Code
+.claude/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Firmware for the OpenTrickler powder trickler controller, targeting Raspberry Pi Pico W (RP2040) and Pico 2W (RP2350) boards. Built on the Pico SDK with FreeRTOS, u8g2/MUI for the mini 12864 display, lwIP/CYW43 for WiFi + REST + web portal, TMC2209 stepper drivers via the Trinamic library, and an on-board I2C EEPROM for persisted config.
+
+## Build commands
+
+All builds require PowerShell and the Raspberry Pi Pico VSCode extension's toolchain (installed under `~/.pico-sdk`). Submodules under `library/` (pico-sdk, FreeRTOS-Kernel, u8g2, Trinamic-library) must be initialized first: `git submodule update --init --recursive`.
+
+Load toolchain env vars into the current PowerShell session before any CMake/Ninja command:
+
+```powershell
+.\configure_env.ps1
+```
+
+Configure + build for a target board (from the same session, first build only needs to configure once):
+
+```powershell
+# Pico 2W (RP2350)
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DPICO_BOARD=pico2_w
+cmake --build build --config Debug
+
+# Pico W (RP2040)
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DPICO_BOARD=pico_w
+```
+
+Convenience scripts that do configure_env + configure + build in one shot:
+- `.\build_pico_2w.ps1` — builds to `build/app.uf2` (pico2_w)
+- `.\build_pico_w.ps1` — builds to `build_w/app.uf2` (pico_w)
+
+Output firmware is `app.uf2` in the corresponding build directory; flash by holding BOOTSEL and copying the file to the Pico's USB mass-storage device.
+
+Launch VSCode with the toolchain env pre-loaded (required for the CMake Tools extension to find the compiler): `.\run_vscode.ps1`. The default board in `.vscode/settings.json` is `pico2_w` — change `PICO_BOARD` there to switch.
+
+### Debugging (Linux/WSL side, via OpenOCD + gdb)
+- `openocd_start.sh` / `openocd_start.bat` — start OpenOCD for a CMSIS-DAP probe against rp2040.cfg
+- `debug.sh` — attach `gdb-multiarch` (TUI) to `build/app.elf` using `scripts/debug.gdb`
+- `program.sh` / `program.bat` — flash `build/app.elf` via gdb using `scripts/program.gdb`
+
+### Testing
+There is no on-device automated test suite. `tests/web_test.py` is a Flask app that serves the generated `web_portal.html` / `wizard.html` and stubs every `/rest/*` endpoint with fake JSON, so the web UI can be developed/iterated in a browser without real hardware:
+
+```
+pip install flask
+python tests/web_test.py
+```
+
+## Architecture
+
+### Build-time code generation (`src/CMakeLists.txt`)
+Three things are generated into `src/generated/` before the app target builds, and are checked in as build artifacts, not hand-edited:
+- `ws2812.pio.h`, `stepper.pio.h` — from `.pio` sources via `pico_generate_pio_header`
+- `web_portal.html.h`, `wizard.html.h`, `display_mirror.html.h` — from `src/html/*.html` via `scripts/html2header.py`, embedding the web UI as C string constants that `rest_endpoints.c` serves directly
+- `version.c` / `version.h` — from `scripts/gen_version.py`, embeds git rev + build type
+
+If you edit `src/html/*.html`, `*.pio` files, or need a fresh version stamp, a rebuild regenerates these automatically — don't hand-edit files under `src/generated/`.
+
+### Startup and task model (`src/app.c`)
+`main()` runs hardware/module init in a fixed order (EEPROM → neopixel → display → wireless → motors → scale UART → charge mode → profile data → servo) before starting a single `menu_task` and handing off to `vTaskStartScheduler()`. Other tasks (display render, scale read loop, wireless/HTTP) are created by their owning modules during that init sequence, not from `main()` directly. Module init order matters because later modules assume earlier hardware (e.g. EEPROM) is already available.
+
+### Module pattern
+Each hardware/feature area is a `feature.c`/`feature.h` (or `.cpp`/`.h` when C++ helpers are needed) pair: `motors`, `scale` (+ per-brand drivers: `and_scale`, `steinberg_scale`, `gng_scale`, `ussolid_scale`, `jm_science_scale`, `creedmoor_scale`, `radwag_scale`, `sartorius_scale`, `generic_scale`), `charge_mode`, `cleanup_mode`, `servo_gate`, `neopixel_led`, `display` / `mini_12864_module` / `menu` / `mui_menu`, `wireless` / `access_point_mode` / `dhcpserver` / `dnsserver`, `eeprom`, `profile`, `system_control`. `scale.h` defines a small vtable-style `scale_handle_t` (`read_loop_task`, `force_zero`) that each brand-specific scale driver implements, selected at runtime via `scale_driver_t`.
+
+### Persistent config (EEPROM)
+`eeprom.h`/`eeprom.c` own the I2C EEPROM and a fixed address map (`EEPROM_*_BASE_ADDR` constants, one 1K-ish region per module: metadata, scale, wireless, motor, charge mode, app config, neopixel, mini12864, profile, servo gate). Each owning module keeps a live in-RAM config struct (`eeprom_*_data_t` / `eeprom_*_metadata_t`), a `const default_*` initializer, `*_config_init()`/`*_config_save()` functions, and registers its save handler via `eeprom_register_handler(...)` so `eeprom_save_all()` can persist everything at once. Preserving EEPROM layout/revision compatibility across firmware versions matters — see the `c-style` skill (Rule 5) before touching any `eeprom_*` struct.
+
+### REST + web portal (`http_rest.*`, `rest_endpoints.*`, `rest_app_control.*`)
+The web UI (served from the generated HTML headers above) talks to the firmware over a compact REST API implemented on top of lwIP's fs/CGI hooks. Handlers have the signature `bool http_rest_*(struct fs_file *file, int num_params, char *params[], char *values[])`, write a static JSON buffer into `file->data`, and set `file->len`/`file->index`/`file->flags` (`FS_FILE_FLAGS_HEADER_INCLUDED`, optionally `+HEADER_PERSISTENT` for static content). Parameter/response keys are short compact codes per module (e.g. `w0`=SSID, `m1`/`m2`=motor params, `c13`=charge param, `ee`=persist-to-EEPROM flag) — `tests/web_test.py` is the best quick reference for the current JSON shapes each endpoint returns. Handlers are wired up in `rest_endpoints_init()` via `rest_register_handler(path, handler)`.
+
+### Hardware target config (`targets/`)
+Board pin/peripheral assignments (UART instances, GPIO numbers, PIO/SPI/I2C instances) live in `targets/raspberrypi_pico_w_config.h`, pulled in through `src/configuration.h`. `PICO_BOARD_HEADER_DIRS` points CMake at this directory. Feature modules should consume pins via these macros, not hard-code them.
+
+### Networking
+`wireless.c` (AP or station mode, mDNS), `access_point_mode.c`, `dhcpserver.c`, `dnsserver.c` implement the on-device network stack on top of lwIP/CYW43, running under FreeRTOS. lwIP calls made outside the network task must be bracketed with `cyw43_arch_lwip_begin()`/`cyw43_arch_lwip_end()` — follow existing call sites in `wireless.c` for the locking pattern.
+
+## Project skills
+
+This repo ships Claude Code skills under `.claude/skills/` (mirrored in `.agents/skills/`) that encode conventions in more depth than this file — they load automatically for matching work:
+- `c-style` — C/C++ conventions for this firmware (naming, module shape, EEPROM pattern, FreeRTOS/PIO/REST/display patterns). Read this before any non-trivial `src/**/*.c|h|cpp` change.
+- `py-style` — Python conventions, applies to `scripts/*.py` and `tests/web_test.py`.
+- `development-plan-writing` — required structure for any development/migration/refactor plan document.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,19 @@ message("CMAKE_SOURCE_DIR: ${CMAKE_SOURCE_DIR}")
 set(ENV{PICO_SDK_PATH} "${CMAKE_SOURCE_DIR}/library/pico-sdk")
 set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
 
+# OTA flash split: physical flash is divided into three regions -- a small
+# bootloader (always at offset 0), the app (chain-loaded by the bootloader),
+# and an OTA staging area (the upper half of the chip, unchanged in size from
+# earlier revisions of this split). See bootloader/main.c and
+# src/firmware_update.c for how these are used. The linker regions for both
+# the "bootloader" and "app" targets are set via a POST-pico_sdk_init()
+# override of their generated linker scripts, near the bottom of this file
+# and in bootloader/CMakeLists.txt, not via a PICO_FLASH_SIZE_BYTES variable
+# set here. See the comment at that override for why: pre-setting
+# PICO_FLASH_SIZE_BYTES before pico_sdk_init() was tried first and caused a
+# severe, silent bug -- root-caused and fixed; kept here as a warning so it
+# isn't reintroduced.
+
 # Include the Pico SDK
 include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
 
@@ -24,11 +37,33 @@ project(${PROJECT_NAME}
 # Initialise the Pico SDK
 pico_sdk_init()
 
+# ---- OTA flash layout (shared by the "app" and "bootloader" targets) ----
+# Physical chip is split in half: the lower half holds [bootloader | app],
+# the upper half is the OTA staging area (unchanged from earlier revisions
+# of this split -- only how the lower half subdivides is new). Computed once
+# here, before either add_subdirectory() below, so both targets' compile
+# definitions and linker regions derive from the same numbers.
+set(BOOTLOADER_FLASH_SIZE_BYTES 65536)   # 64 KiB -- ample for a footer-check + flash-copy + chain-load
+if(PICO_BOARD STREQUAL "pico2_w")
+    set(FIRMWARE_UPDATE_TOTAL_FLASH_SIZE 4194304)   # 4 MiB physical chip
+    set(FIRMWARE_UPDATE_BOARD_TYPE FIRMWARE_BOARD_TYPE_PICO2_W)
+    set(FIRMWARE_UPDATE_BATCH_SIZE 131072)          # 128 KiB (32 sectors) -- upload flash-write batch size
+else()
+    set(FIRMWARE_UPDATE_TOTAL_FLASH_SIZE 2097152)   # 2 MiB physical chip
+    set(FIRMWARE_UPDATE_BOARD_TYPE FIRMWARE_BOARD_TYPE_PICO_W)
+    set(FIRMWARE_UPDATE_BATCH_SIZE 32768)           # 32 KiB (8 sectors) -- upload flash-write batch size
+endif()
+math(EXPR FIRMWARE_UPDATE_STAGING_OFFSET "${FIRMWARE_UPDATE_TOTAL_FLASH_SIZE} / 2")
+set(FIRMWARE_UPDATE_STAGING_SIZE ${FIRMWARE_UPDATE_STAGING_OFFSET})
+set(FIRMWARE_UPDATE_APP_REGION_OFFSET ${BOOTLOADER_FLASH_SIZE_BYTES})
+math(EXPR FIRMWARE_UPDATE_APP_REGION_SIZE "${FIRMWARE_UPDATE_STAGING_OFFSET} - ${BOOTLOADER_FLASH_SIZE_BYTES}")
+
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 
 # Set flags and directory variables
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0 -DDEBUG")
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O2")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -DDEBUG")
 set(SRC_DIRECTORY "${CMAKE_SOURCE_DIR}/src")
 set(FREERTOS_SRC_DIRECTORY "${CMAKE_SOURCE_DIR}/library/FreeRTOS-Kernel")
@@ -81,6 +116,11 @@ target_link_libraries(u8g2_mui u8g2)
 # Pull in src
 add_subdirectory(${SRC_DIRECTORY})
 
+# Pull in the OTA second-stage bootloader (separate executable, see
+# bootloader/CMakeLists.txt) -- it consumes the OTA flash layout variables
+# set above.
+add_subdirectory(bootloader)
+
 # Collect all source files
 file(GLOB SRC ${SRC_DIRECTORY}/*.c 
               ${SRC_DIRECTORY}/*.cpp)
@@ -100,6 +140,8 @@ target_link_libraries("${TARGET_NAME}"
     hardware_spi
     hardware_i2c
     hardware_pwm
+    hardware_flash
+    pico_flash
     FreeRTOS-Kernel
     FreeRTOS-Kernel-Heap4
     u8g2
@@ -119,3 +161,68 @@ target_link_options("${TARGET_NAME}" PUBLIC -Wl,--gc-sections -Wl,--print-memory
 
 # Generate extra outputs
 pico_add_extra_outputs("${TARGET_NAME}")
+
+# OTA firmware image: append the footer (see src/firmware_footer.h) to the
+# plain app.bin that pico_add_extra_outputs just produced, yielding
+# app_ota.bin -- the file users upload through the web UI. This must be
+# registered AFTER pico_add_extra_outputs (which is what actually adds the
+# POST_BUILD step that generates app.bin from app.elf), since POST_BUILD
+# commands on a target run in the order they were added.
+#
+# find_package is re-run here (rather than reusing src/CMakeLists.txt's call)
+# because Python_EXECUTABLE is scoped to the directory that found it and does
+# not propagate back up through add_subdirectory(); this call is cheap since
+# CMake already cached the interpreter location.
+find_package(Python COMPONENTS Interpreter REQUIRED)
+add_custom_command(TARGET "${TARGET_NAME}" POST_BUILD
+    COMMAND "${Python_EXECUTABLE}" "${SCRIPTS_DIRECTORY}/append_firmware_footer.py"
+            --input "$<TARGET_FILE_DIR:${TARGET_NAME}>/${TARGET_NAME}.bin"
+            --output "$<TARGET_FILE_DIR:${TARGET_NAME}>/${TARGET_NAME}_ota.bin"
+            --board "${PICO_BOARD}"
+    COMMENT "Appending OTA footer -> ${TARGET_NAME}_ota.bin"
+    VERBATIM
+)
+
+# OTA flash split: shrink the linker's FLASH region for the "app" target to
+# FIRMWARE_UPDATE_APP_REGION_SIZE, starting at FIRMWARE_UPDATE_APP_REGION_OFFSET
+# (i.e. right after the bootloader's own 64 KiB region -- see
+# bootloader/CMakeLists.txt for its region, and bootloader/main.c for how it
+# chain-loads into this one). The upper half of the chip remains the OTA
+# staging area (see src/firmware_update.c).
+#
+# This directly overwrites the tiny pico_flash_region.ld fragment that
+# pico_standard_link's own CMakeLists.txt already generated (using the
+# board's full physical flash size) during pico_sdk_init() above. Placed
+# here, after everything else in this file, this file(WRITE) is guaranteed
+# to be the last write to that path during this CMake configure run,
+# regardless of exactly when the SDK generated its own version internally --
+# no need to know or depend on that internal ordering.
+#
+# WHY NOT set(PICO_FLASH_SIZE_BYTES ...) BEFORE pico_sdk_init(), as tried
+# originally: pico_w.h/pico2_w.h declare their physical flash size via a
+# magic "pico_cmake_set_default PICO_FLASH_SIZE_BYTES = ..." comment pragma
+# that the SDK's generic_board.cmake scans for. If that exact CMake variable
+# name is *already defined* by the time pico_sdk_init() parses that pragma,
+# the SDK assumes the user is deliberately overriding a board default and
+# promotes it to a GLOBAL C COMPILE DEFINITION via pico_base_headers (see
+# library/pico-sdk/cmake/generic_board.cmake and
+# library/pico-sdk/src/common/pico_base_headers/CMakeLists.txt) -- silently
+# defeating the whole point, since hardware_flash's flash_range_erase/
+# program bounds-check against that same macro name, expecting the
+# *physical* chip size:
+#   hard_assert(flash_offs + count <= PICO_FLASH_SIZE_BYTES);   // flash.c
+# With the shrunk (app-region) size compiled in instead, every OTA write
+# into the staging region (which starts exactly at that shrunk value) failed
+# this assert -- a silent, total, unrecoverable hang on every single OTA
+# flash write, independent of any multicore-safety configuration, since the
+# assert fires inside flash_range_erase/program itself, before any
+# multicore coordination is even reached. Confirmed directly by inspecting
+# the generated build.ninja: hardware_flash/flash.c.obj was being compiled
+# with -DPICO_FLASH_SIZE_BYTES="<shrunk value>". Never pre-set
+# PICO_FLASH_SIZE_BYTES (or any other name a board header declares via a
+# pico_cmake_set/pico_cmake_set_default pragma) before pico_sdk_init() for
+# this reason -- override the generated linker fragment afterward instead,
+# as done here.
+math(EXPR OTA_APP_FLASH_ORIGIN "0x10000000 + ${FIRMWARE_UPDATE_APP_REGION_OFFSET}" OUTPUT_FORMAT HEXADECIMAL)
+file(WRITE "${CMAKE_BINARY_DIR}/pico_flash_region.ld"
+     "FLASH(rx) : ORIGIN = ${OTA_APP_FLASH_ORIGIN}, LENGTH = ${FIRMWARE_UPDATE_APP_REGION_SIZE}\n")

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,15 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": ""
+    }
+  ]
+}

--- a/bootloader/CMakeLists.txt
+++ b/bootloader/CMakeLists.txt
@@ -1,0 +1,53 @@
+# Second-stage OTA bootloader: a small, separate, single-threaded executable
+# that runs before the main "app" target on every boot. See main.c for what
+# it does and why. Consumes the OTA flash layout variables set in the root
+# CMakeLists.txt, before this subdirectory is added.
+
+add_executable(bootloader
+    main.c
+)
+
+target_include_directories(bootloader PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+)
+
+target_include_directories(bootloader PUBLIC ${CMAKE_SOURCE_DIR}/targets)
+
+target_link_libraries(bootloader
+    pico_stdlib
+    hardware_flash
+    hardware_resets
+    pico_bootrom
+)
+
+target_compile_definitions(bootloader PRIVATE
+    FIRMWARE_UPDATE_STAGING_OFFSET=${FIRMWARE_UPDATE_STAGING_OFFSET}
+    FIRMWARE_UPDATE_STAGING_SIZE=${FIRMWARE_UPDATE_STAGING_SIZE}
+    FIRMWARE_UPDATE_APP_REGION_OFFSET=${FIRMWARE_UPDATE_APP_REGION_OFFSET}
+    FIRMWARE_UPDATE_APP_REGION_SIZE=${FIRMWARE_UPDATE_APP_REGION_SIZE}
+    FIRMWARE_UPDATE_BOARD_TYPE=${FIRMWARE_UPDATE_BOARD_TYPE}
+)
+
+target_link_options(bootloader PUBLIC -Wl,--gc-sections -Wl,--print-memory-usage)
+
+pico_add_extra_outputs(bootloader)
+
+# Custom, self-contained flash region for this target, derived fresh (at
+# configure time) from the SDK's own per-platform default memmap template,
+# with only the MEMORY block's FLASH region replaced. A custom linker script
+# (rather than the shared pico_flash_region.ld override the "app" target
+# uses, see root CMakeLists.txt) is required here because both targets link
+# against pico_standard_link, which only generates ONE shared
+# pico_flash_region.ld per build directory -- two targets needing two
+# different FLASH regions can't both come from that one shared, global file.
+# Deriving this from the SDK's live template (rather than a hand-maintained
+# copy) means it can't silently drift out of sync with the vendored SDK.
+file(READ "${PICO_LINKER_SCRIPT_PATH}/memmap_default.ld" _bootloader_memmap_template)
+string(REPLACE
+    "INCLUDE \"pico_flash_region.ld\""
+    "FLASH(rx) : ORIGIN = 0x10000000, LENGTH = ${BOOTLOADER_FLASH_SIZE_BYTES}"
+    _bootloader_memmap_content
+    "${_bootloader_memmap_template}"
+)
+file(WRITE "${CMAKE_BINARY_DIR}/memmap_bootloader.ld" "${_bootloader_memmap_content}")
+pico_set_linker_script(bootloader "${CMAKE_BINARY_DIR}/memmap_bootloader.ld")

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -78,20 +78,19 @@ static bool read_and_validate_footer(firmware_update_footer_t *out) {
     return true;
 }
 
-// Rewrites the footer with install_pending cleared. Only ever called after
-// copy_staged_image_to_app_region() has fully completed, so a power loss
-// before this point simply leaves install_pending set and the copy retries
-// from scratch (from the untouched staging-region source data) on the next
-// boot -- see the plan's "power-loss safety" design decision.
-static void clear_install_pending(firmware_update_footer_t *footer) {
-    footer->reserved[FIRMWARE_FOOTER_INSTALL_PENDING_BYTE] = 0;
-    footer->footer_crc32 = compute_footer_crc32(footer);
-
-    memset(s_sector_buf, 0xFF, FLASH_SECTOR_SIZE);
-    memcpy(&s_sector_buf[FLASH_SECTOR_SIZE - FIRMWARE_FOOTER_SIZE], footer, FIRMWARE_FOOTER_SIZE);
-
+// Invalidates the staged image entirely (erasing the footer sector removes
+// its magic, so firmware_update_get_staged_info() correctly reports "no
+// image staged" afterward) -- not just the install-pending flag. Without
+// this, the web UI kept showing the just-installed version as still
+// "staged", since a valid-but-pending-cleared footer is indistinguishable
+// from a valid-and-ready-to-install one from the REST status's point of
+// view. Only ever called after copy_staged_image_to_app_region() has fully
+// completed, so a power loss before this point simply leaves the original
+// footer (install_pending still set) in place and the copy retries from
+// scratch (from the untouched staging-region source data) on the next boot
+// -- see the plan's "power-loss safety" design decision.
+static void invalidate_staged_image(void) {
     flash_range_erase(FIRMWARE_UPDATE_FOOTER_SECTOR_OFFSET, FLASH_SECTOR_SIZE);
-    flash_range_program(FIRMWARE_UPDATE_FOOTER_SECTOR_OFFSET, s_sector_buf, FLASH_SECTOR_SIZE);
 }
 
 // Plain flash_range_erase/program calls, no flash_safe_execute: this is the
@@ -174,7 +173,7 @@ int main(void) {
 
     if (read_and_validate_footer(&footer) && footer.reserved[FIRMWARE_FOOTER_INSTALL_PENDING_BYTE] != 0) {
         copy_staged_image_to_app_region(footer.payload_size);
-        clear_install_pending(&footer);
+        invalidate_staged_image();
     }
 
     chain_to_app();

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -1,0 +1,181 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "pico.h"
+#include "hardware/flash.h"
+#include "hardware/regs/addressmap.h"
+#include "hardware/resets.h"
+#include "hardware/structs/scb.h"
+#include "hardware/sync.h"
+
+#if PICO_RP2040
+#include "hardware/structs/m0plus.h"
+#endif
+
+#if PICO_RP2350
+#include "pico/bootrom.h"
+#endif
+
+#include "firmware_footer.h"
+
+// This bootloader is deliberately minimal: no FreeRTOS, no networking, no
+// display, single core, single-threaded. Its only job, on every boot, is to
+// check whether a validated OTA image is staged and pending install and, if
+// so, copy it into the app region before chain-loading into the app -- see
+// src/firmware_update.c's history for why doing this copy live, under
+// FreeRTOS with a second core running, proved unsafe. With nothing else
+// running here, the copy needs none of flash_safe_execute's multicore
+// lockout machinery: there is no other core or interrupt context that could
+// ever fetch a partially-overwritten instruction from the app region while
+// this runs.
+
+#define FIRMWARE_UPDATE_FOOTER_OFFSET \
+    (FIRMWARE_UPDATE_STAGING_OFFSET + FIRMWARE_UPDATE_STAGING_SIZE - FIRMWARE_FOOTER_SIZE)
+#define FIRMWARE_UPDATE_FOOTER_SECTOR_OFFSET \
+    (FIRMWARE_UPDATE_STAGING_OFFSET + FIRMWARE_UPDATE_STAGING_SIZE - FLASH_SECTOR_SIZE)
+
+static uint8_t s_sector_buf[FLASH_SECTOR_SIZE] __attribute__((aligned(4)));
+
+// Standalone CRC32 (same standard reflected algorithm, same init/xorout, as
+// src/common.c's software_crc32_* -- reimplemented here rather than shared,
+// since common.c pulls in FreeRTOS and EEPROM dependencies this target must
+// not link).
+static uint32_t compute_crc32(const void *data, size_t length) {
+    uint32_t crc = 0xFFFFFFFFu;
+    const uint8_t *p = (const uint8_t *)data;
+
+    while (length--) {
+        crc ^= *p++;
+        for (int bit = 0; bit < 8; bit += 1) {
+            uint32_t mask = -(crc & 1u);
+            crc = (crc >> 1) ^ (0xEDB88320u & mask);
+        }
+    }
+
+    return crc ^ 0xFFFFFFFFu;
+}
+
+static uint32_t compute_footer_crc32(const firmware_update_footer_t *footer) {
+    return compute_crc32(footer, FIRMWARE_FOOTER_SIZE - sizeof(uint32_t));
+}
+
+static bool read_and_validate_footer(firmware_update_footer_t *out) {
+    const firmware_update_footer_t *footer =
+        (const firmware_update_footer_t *)(XIP_BASE + FIRMWARE_UPDATE_FOOTER_OFFSET);
+
+    if (footer->magic != FIRMWARE_FOOTER_MAGIC) {
+        return false;
+    }
+    if (footer->board_type != FIRMWARE_UPDATE_BOARD_TYPE) {
+        return false;
+    }
+    if (compute_footer_crc32(footer) != footer->footer_crc32) {
+        return false;
+    }
+
+    memcpy(out, footer, sizeof(*out));
+    return true;
+}
+
+// Rewrites the footer with install_pending cleared. Only ever called after
+// copy_staged_image_to_app_region() has fully completed, so a power loss
+// before this point simply leaves install_pending set and the copy retries
+// from scratch (from the untouched staging-region source data) on the next
+// boot -- see the plan's "power-loss safety" design decision.
+static void clear_install_pending(firmware_update_footer_t *footer) {
+    footer->reserved[FIRMWARE_FOOTER_INSTALL_PENDING_BYTE] = 0;
+    footer->footer_crc32 = compute_footer_crc32(footer);
+
+    memset(s_sector_buf, 0xFF, FLASH_SECTOR_SIZE);
+    memcpy(&s_sector_buf[FLASH_SECTOR_SIZE - FIRMWARE_FOOTER_SIZE], footer, FIRMWARE_FOOTER_SIZE);
+
+    flash_range_erase(FIRMWARE_UPDATE_FOOTER_SECTOR_OFFSET, FLASH_SECTOR_SIZE);
+    flash_range_program(FIRMWARE_UPDATE_FOOTER_SECTOR_OFFSET, s_sector_buf, FLASH_SECTOR_SIZE);
+}
+
+// Plain flash_range_erase/program calls, no flash_safe_execute: this is the
+// only code running on the only core that's started, so there is nothing to
+// lock out.
+static void copy_staged_image_to_app_region(uint32_t payload_size) {
+    uint32_t total_bytes = ((payload_size + FLASH_SECTOR_SIZE - 1) / FLASH_SECTOR_SIZE) * FLASH_SECTOR_SIZE;
+
+    for (uint32_t offset = 0; offset < total_bytes; offset += FLASH_SECTOR_SIZE) {
+        const uint8_t *src = (const uint8_t *)(XIP_BASE + FIRMWARE_UPDATE_STAGING_OFFSET + offset);
+        memcpy(s_sector_buf, src, FLASH_SECTOR_SIZE);
+
+        flash_range_erase(FIRMWARE_UPDATE_APP_REGION_OFFSET + offset, FLASH_SECTOR_SIZE);
+        flash_range_program(FIRMWARE_UPDATE_APP_REGION_OFFSET + offset, s_sector_buf, FLASH_SECTOR_SIZE);
+    }
+}
+
+// Chain-loads into the app region. Never returns.
+static void __attribute__((noreturn)) chain_to_app(void) {
+#if PICO_RP2350
+    // Official bootrom API for exactly this: validates the app's own
+    // IMAGE_DEF within the given window and transfers control to it.
+    // pico_add_extra_outputs already embeds IMAGE_DEF in the app build by
+    // default, so no changes are needed there.
+    rom_chain_image(s_sector_buf, sizeof(s_sector_buf),
+                     XIP_BASE + FIRMWARE_UPDATE_APP_REGION_OFFSET, FIRMWARE_UPDATE_APP_REGION_SIZE);
+    // Only reached if the app region has no valid image to chain into.
+    while (true) {
+        tight_loop_contents();
+    }
+#else
+    // RP2040 has no chain-load ROM API. This mirrors exactly what boot2
+    // itself does for a normal (directly-booted) app: the app region's
+    // first 256 bytes are its own (unused, never executed here) .boot2
+    // slot, immediately followed by its vector table -- same layout a
+    // directly-booted image already has (confirmed via objdump earlier in
+    // this project's history).
+    uint32_t app_vector_table = XIP_BASE + FIRMWARE_UPDATE_APP_REGION_OFFSET + 0x100u;
+    uint32_t *vtable = (uint32_t *)app_vector_table;
+    uint32_t app_sp = vtable[0];
+    uint32_t app_reset_handler = vtable[1];
+
+    // Mirror picowota's proven jump sequence exactly, not just PRIMASK: a
+    // plain save_and_disable_interrupts() leaves individual NVIC enable/
+    // pending bits and every peripheral's own state untouched. Confirmed by
+    // testing that skipping this leaves the app's LCD working but its
+    // CYW43/PIO-based wireless init broken specifically after the
+    // bootloader has just run a real copy (more of the bootloader's own
+    // init has executed by then than on a pure pass-through chain-load).
+    // reset_block puts every peripheral except QSPI IO/pads, SYSCFG, and
+    // PLL_SYS (needed to keep executing from flash) back into power-on-
+    // reset state -- including PIO -- so the app's own init starts from the
+    // same clean slate it would on a real cold boot. No corresponding
+    // unreset_block() call: the app's own runtime_init() un-resets what it
+    // needs, same as after any normal boot.
+    save_and_disable_interrupts();
+    ppb_hw->syst_csr &= ~M0PLUS_SYST_CSR_ENABLE_BITS;
+    ppb_hw->nvic_icer = 0xFFFFFFFFu;
+    ppb_hw->nvic_icpr = 0xFFFFFFFFu;
+    reset_block(~(RESETS_RESET_IO_QSPI_BITS |
+                  RESETS_RESET_PADS_QSPI_BITS |
+                  RESETS_RESET_SYSCFG_BITS |
+                  RESETS_RESET_PLL_SYS_BITS));
+
+    scb_hw->vtor = app_vector_table;
+    __asm volatile (
+        "msr msp, %0\n"
+        "bx %1\n"
+        :
+        : "r" (app_sp), "r" (app_reset_handler)
+    );
+    while (true) {
+        tight_loop_contents();
+    }
+#endif
+}
+
+int main(void) {
+    firmware_update_footer_t footer;
+
+    if (read_and_validate_footer(&footer) && footer.reserved[FIRMWARE_FOOTER_INSTALL_PENDING_BYTE] != 0) {
+        copy_staged_image_to_app_region(footer.payload_size);
+        clear_install_pending(&footer);
+    }
+
+    chain_to_app();
+}

--- a/configure_env.ps1
+++ b/configure_env.ps1
@@ -8,10 +8,10 @@ $env:Path = "$env:USERPROFILE\.pico-sdk\ninja\v1.12.1;" + $env:Path
 $env:Path = "$env:USERPROFILE\.pico-sdk\cmake\v3.31.5\bin;" + $env:Path
 
 # Specify picotool path
-$env:Path = "$env:USERPROFILE\.pico-sdk\picotool\2.1.1\picotool;" + $env:Path
+$env:Path = "$env:USERPROFILE\.pico-sdk\picotool\2.2.0\picotool;" + $env:Path
 
 # Specify pioasm path
-$env:Path = "$env:USERPROFILE\.pico-sdk\tools\2.1.1\pioasm;" + $env:Path
+$env:Path = "$env:USERPROFILE\.pico-sdk\tools\2.2.0\pioasm;" + $env:Path
 
 # Specify OpenOCD Path
 $OPENOCD_PATH = "$env:USERPROFILE\.pico-sdk\openocd\0.12.0+dev"
@@ -22,3 +22,33 @@ $env:OPENOCD_SCRIPTS = "$OPENOCD_PATH\scripts"
 
 # Specify PICO_TOOLCHAIN_PATH
 $env:PICO_TOOLCHAIN_PATH="$env:USERPROFILE\.pico-sdk\toolchain\14_2_Rel1"
+
+# Load the MSVC host-compiler environment (cl.exe, INCLUDE, LIB, etc.).
+# The Pico SDK builds pioasm from source as a host tool (see
+# library/pico-sdk/tools/Findpioasm.cmake), which needs a native Windows
+# compiler completely separate from the arm-none-eabi-gcc cross-compiler
+# above. VSCode's CMake Tools extension finds this for you automatically;
+# a plain PowerShell session needs it loaded explicitly.
+$vswherePath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+if (Test-Path $vswherePath) {
+    $vsInstallPath = & $vswherePath -latest -products * -property installationPath
+    if ($vsInstallPath) {
+        $vcvars64Path = Join-Path $vsInstallPath "VC\Auxiliary\Build\vcvars64.bat"
+        if (Test-Path $vcvars64Path) {
+            cmd /c "`"$vcvars64Path`" && set" | ForEach-Object {
+                if ($_ -match "^([^=]+)=(.*)$") {
+                    Set-Item -Path "env:$($matches[1])" -Value $matches[2]
+                }
+            }
+        }
+        else {
+            Write-Warning "vcvars64.bat not found under '$vsInstallPath' -- host tool builds (e.g. pioasm) may fail to find a C++ compiler."
+        }
+    }
+    else {
+        Write-Warning "No Visual Studio / Build Tools installation found via vswhere -- host tool builds (e.g. pioasm) may fail to find a C++ compiler."
+    }
+}
+else {
+    Write-Warning "vswhere.exe not found -- install Visual Studio Build Tools (Desktop development with C++) or host tool builds (e.g. pioasm) may fail to find a C++ compiler."
+}

--- a/scripts/append_firmware_footer.py
+++ b/scripts/append_firmware_footer.py
@@ -1,0 +1,157 @@
+"""
+Appends an OTA metadata footer to a built app.bin, producing app_ota.bin.
+
+The footer layout mirrors src/firmware_footer.h's firmware_update_footer_t
+exactly (packed, little-endian, 128 bytes total) -- the two must be kept in
+sync by hand, since this script has no way to parse the C header.
+
+Usage
+
+    python append_firmware_footer.py --input app.bin --output app_ota.bin --board pico2_w
+
+Dependencies: none beyond the standard library.
+"""
+
+import argparse
+import logging
+import re
+import struct
+import subprocess
+import sys
+import zlib
+
+
+GIT_VERSION_COMMAND = ["git", "describe", "--tags", "--long", "--dirty", "--always"]
+
+GIT_VERSION_PATTERN_REGEX = r'v(?P<major>\d+)\.(?P<minor>\d+)-(?P<patch>\d+)-g(?P<short_hash>[a-f0-9]+)(?P<dirty>-dirty)?'
+
+FIRMWARE_FOOTER_MAGIC = 0x4B52544F
+FIRMWARE_FOOTER_FORMAT_VERSION = 1
+FIRMWARE_FOOTER_VERSION_STRLEN = 32
+FIRMWARE_FOOTER_HASH_STRLEN = 16
+FIRMWARE_FOOTER_RESERVED_LEN = 60
+FIRMWARE_FOOTER_SIZE = 128
+
+BOARD_TYPE_BY_PICO_BOARD = {
+    "pico_w": 1,     # FIRMWARE_BOARD_TYPE_PICO_W
+    "pico2_w": 2,    # FIRMWARE_BOARD_TYPE_PICO2_W
+}
+
+# Struct format for everything except the trailing footer_crc32, which is
+# computed over these bytes and appended separately.
+FOOTER_BODY_STRUCT_FORMAT = (
+    "<"    # little-endian, standard sizes, no implicit padding
+    "I"    # magic
+    "H"    # footer_format_version
+    "H"    # board_type
+    "I"    # payload_size
+    "I"    # payload_crc32
+    f"{FIRMWARE_FOOTER_VERSION_STRLEN}s"  # version_string
+    f"{FIRMWARE_FOOTER_HASH_STRLEN}s"     # vcs_hash
+    f"{FIRMWARE_FOOTER_RESERVED_LEN}s"    # reserved
+)
+
+
+def get_git_version_and_hash():
+    """Derive the firmware version string and short VCS hash from git.
+
+    Mirrors scripts/gen_version.py's own git-describe parsing so the footer's
+    embedded version matches what version_string/vcs_hash report at runtime.
+
+    Returns:
+        A (version_string, hash_string) tuple. version_string is "unknown"
+        and hash_string is "" if the working tree isn't a recognizable
+        annotated-tag checkout.
+    """
+    output = subprocess.check_output(GIT_VERSION_COMMAND, text=True)
+    match = re.match(GIT_VERSION_PATTERN_REGEX, output)
+
+    if not match:
+        return "unknown", ""
+
+    groupdict = match.groupdict()
+    dirty_string = groupdict["dirty"] or ""
+    version_string = f"{groupdict['major']}.{groupdict['minor']}.{groupdict['patch']}{dirty_string}"
+    return version_string, groupdict["short_hash"]
+
+
+def build_footer(payload: bytes, board_type: int, version_string: str, vcs_hash: str) -> bytes:
+    """Build the 128-byte OTA footer for a given firmware payload.
+
+    Args:
+        payload: The raw app.bin bytes the footer will describe.
+        board_type: firmware_board_type_t value (see BOARD_TYPE_BY_PICO_BOARD).
+        version_string: Human-readable version, truncated/NUL-padded to fit.
+        vcs_hash: Short git hash, truncated/NUL-padded to fit.
+
+    Returns:
+        The 128-byte packed footer, including its own trailing CRC32.
+    """
+    payload_crc32 = zlib.crc32(payload) & 0xFFFFFFFF
+
+    body = struct.pack(
+        FOOTER_BODY_STRUCT_FORMAT,
+        FIRMWARE_FOOTER_MAGIC,
+        FIRMWARE_FOOTER_FORMAT_VERSION,
+        board_type,
+        len(payload),
+        payload_crc32,
+        version_string.encode("ascii", errors="replace"),
+        vcs_hash.encode("ascii", errors="replace"),
+        b"\x00" * FIRMWARE_FOOTER_RESERVED_LEN,
+    )
+
+    footer_crc32 = zlib.crc32(body) & 0xFFFFFFFF
+    footer = body + struct.pack("<I", footer_crc32)
+
+    assert len(footer) == FIRMWARE_FOOTER_SIZE, f"footer size {len(footer)} != {FIRMWARE_FOOTER_SIZE}"
+    return footer
+
+
+def main(input_path: str, output_path: str, board: str):
+    """Read app.bin, append its OTA footer, and write app_ota.bin.
+
+    Args:
+        input_path: Path to the plain, footer-less app.bin produced by
+            pico_add_extra_outputs.
+        output_path: Path to write the footer-appended OTA image to.
+        board: PICO_BOARD value ("pico_w" or "pico2_w") the image was built for.
+    """
+    if board not in BOARD_TYPE_BY_PICO_BOARD:
+        raise ValueError(f"Unknown PICO_BOARD '{board}', expected one of {sorted(BOARD_TYPE_BY_PICO_BOARD)}")
+
+    with open(input_path, "rb") as fp:
+        payload = fp.read()
+
+    version_string, vcs_hash = get_git_version_and_hash()
+    logging.debug(f"version_string={version_string} vcs_hash={vcs_hash}")
+
+    footer = build_footer(payload, BOARD_TYPE_BY_PICO_BOARD[board], version_string, vcs_hash)
+
+    with open(output_path, "wb") as fp:
+        fp.write(payload)
+        fp.write(footer)
+
+    logging.debug(f"Wrote {output_path}: payload={len(payload)}B footer={len(footer)}B")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--input", help="Path to the input app.bin", required=True)
+    parser.add_argument("--output", help="Path to write the footer-appended app_ota.bin to", required=True)
+    parser.add_argument("--board", help="PICO_BOARD value the image was built for", required=True)
+    parser.add_argument("-v", "--verbose", action="count", default=0)
+
+    args = parser.parse_args()
+
+    logging_levels = {0: logging.ERROR,
+                       1: logging.DEBUG,
+                       2: logging.INFO,
+                       3: logging.WARNING,
+                       4: logging.ERROR,
+                       5: logging.CRITICAL}
+
+    logging.basicConfig(stream=sys.stdout, level=logging_levels[args.verbose])
+
+    main(args.input, args.output, args.board)

--- a/scripts/merge_initial_flash_uf2.py
+++ b/scripts/merge_initial_flash_uf2.py
@@ -1,0 +1,167 @@
+"""
+Merges the bootloader and app .bin outputs into a single UF2 image for the
+one-time manual BOOTSEL reflash needed to adopt the bootloader/app/staging
+flash split (see bootloader/CMakeLists.txt and the root CMakeLists.txt).
+Every OTA update after this initial flash goes through the normal
+upload/stage/install REST flow instead.
+
+The UF2 family ID and flags are read from an existing, already-built
+reference .uf2 for the same board (pico_add_extra_outputs already produces
+one per target) rather than hardcoded, since RP2040 and RP2350 use different
+family IDs and this avoids getting either wrong.
+
+Usage
+
+    python merge_initial_flash_uf2.py \
+        --bootloader-bin bootloader/bootloader.bin \
+        --app-bin app.bin \
+        --app-offset 0x10010000 \
+        --reference-uf2 bootloader/bootloader.uf2 \
+        --output initial_flash.uf2
+
+Dependencies: none beyond the standard library.
+"""
+
+import argparse
+import struct
+import sys
+
+
+UF2_MAGIC_START0 = 0x0A324655
+UF2_MAGIC_START1 = 0x9E5D5157
+UF2_MAGIC_END = 0x0AB16F30
+UF2_FLAG_FAMILY_ID_PRESENT = 0x00002000
+UF2_BLOCK_SIZE = 512
+UF2_DATA_SIZE = 256
+UF2_HEADER = "<IIIIIIII"
+BOOTLOADER_ORIGIN = 0x10000000
+
+
+def read_family_id_and_flags(reference_uf2_path: str) -> tuple:
+    """Extract the UF2 flags and family ID from an existing .uf2's first block.
+
+    Args:
+        reference_uf2_path: Path to any already-built .uf2 for the target
+            board (family ID/flags are the same across all targets built for
+            the same board -- see pico_add_extra_outputs).
+
+    Returns:
+        A (flags, family_id) tuple as found in the reference file's first
+        block header.
+    """
+    with open(reference_uf2_path, "rb") as fp:
+        first_block = fp.read(UF2_BLOCK_SIZE)
+
+    (magic_start0, magic_start1, flags, _target_addr, _payload_size,
+     _block_no, _num_blocks, family_id) = struct.unpack(UF2_HEADER, first_block[:32])
+
+    if magic_start0 != UF2_MAGIC_START0 or magic_start1 != UF2_MAGIC_START1:
+        raise ValueError(f"{reference_uf2_path} does not look like a UF2 file")
+    if not (flags & UF2_FLAG_FAMILY_ID_PRESENT):
+        raise ValueError(f"{reference_uf2_path}'s first block has no family ID present")
+
+    return flags, family_id
+
+
+def build_uf2_blocks(data: bytes, target_addr: int, flags: int, family_id: int,
+                      block_no: int, num_blocks: int) -> bytes:
+    """Chunk `data` into UF2_DATA_SIZE-byte UF2 blocks starting at target_addr.
+
+    Args:
+        data: Raw binary payload to encode.
+        target_addr: Flash address the first byte of `data` should be
+            written to.
+        flags: UF2 flags to stamp into every block (see UF2_FLAG_FAMILY_ID_PRESENT).
+        family_id: UF2 family ID to stamp into every block.
+        block_no: Global block index to start counting from (spans across
+            both the bootloader's and the app's blocks in the merged file).
+        num_blocks: Total block count across the whole merged file.
+
+    Returns:
+        The concatenated raw bytes of all UF2 blocks for this payload.
+    """
+    output = bytearray()
+
+    for offset in range(0, len(data), UF2_DATA_SIZE):
+        chunk = data[offset:offset + UF2_DATA_SIZE]
+        padded_chunk = chunk.ljust(UF2_DATA_SIZE, b"\x00")
+
+        header = struct.pack(
+            UF2_HEADER,
+            UF2_MAGIC_START0, UF2_MAGIC_START1, flags,
+            target_addr + offset, UF2_DATA_SIZE, block_no, num_blocks, family_id,
+        )
+        padding = b"\x00" * (UF2_BLOCK_SIZE - len(header) - UF2_DATA_SIZE - 4)
+        footer = struct.pack("<I", UF2_MAGIC_END)
+
+        output += header + padded_chunk + padding + footer
+        block_no += 1
+
+    return bytes(output)
+
+
+def main(bootloader_bin_path: str, app_bin_path: str, app_offset: int,
+         reference_uf2_path: str, output_path: str):
+    """Build a merged UF2 covering both the bootloader and app flash regions.
+
+    Args:
+        bootloader_bin_path: Path to the built bootloader.bin.
+        app_bin_path: Path to the built app.bin (plain, footer-less --
+            the OTA footer is only relevant to app_ota.bin, uploaded later
+            through the web UI, not to this one-time direct flash).
+        app_offset: Flash address the app region starts at (must match
+            FIRMWARE_UPDATE_APP_REGION_OFFSET for the board being built).
+        reference_uf2_path: Any already-built .uf2 for the same board, used
+            to source the correct UF2 family ID/flags.
+        output_path: Path to write the merged initial_flash.uf2 to.
+    """
+    with open(bootloader_bin_path, "rb") as fp:
+        bootloader_data = fp.read()
+    with open(app_bin_path, "rb") as fp:
+        app_data = fp.read()
+
+    flags, family_id = read_family_id_and_flags(reference_uf2_path)
+
+    total_blocks = (
+        (len(bootloader_data) + UF2_DATA_SIZE - 1) // UF2_DATA_SIZE
+        + (len(app_data) + UF2_DATA_SIZE - 1) // UF2_DATA_SIZE
+    )
+
+    bootloader_blocks = build_uf2_blocks(
+        bootloader_data, BOOTLOADER_ORIGIN, flags, family_id,
+        block_no=0, num_blocks=total_blocks,
+    )
+    bootloader_block_count = len(bootloader_blocks) // UF2_BLOCK_SIZE
+
+    app_blocks = build_uf2_blocks(
+        app_data, app_offset, flags, family_id,
+        block_no=bootloader_block_count, num_blocks=total_blocks,
+    )
+
+    with open(output_path, "wb") as fp:
+        fp.write(bootloader_blocks)
+        fp.write(app_blocks)
+
+    print(f"Wrote {output_path}: {total_blocks} blocks "
+          f"(bootloader @ 0x{BOOTLOADER_ORIGIN:08X}, app @ 0x{app_offset:08X})")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--bootloader-bin", required=True, help="Path to the built bootloader.bin")
+    parser.add_argument("--app-bin", required=True, help="Path to the built app.bin (plain, footer-less)")
+    parser.add_argument("--app-offset", required=True, type=lambda s: int(s, 0),
+                         help="Flash address the app region starts at, e.g. 0x10010000")
+    parser.add_argument("--reference-uf2", required=True,
+                         help="Any already-built .uf2 for the same board, to source the UF2 family ID/flags")
+    parser.add_argument("--output", required=True, help="Path to write the merged UF2 to")
+
+    args = parser.parse_args()
+
+    if args.app_offset <= BOOTLOADER_ORIGIN:
+        print(f"error: --app-offset (0x{args.app_offset:08X}) must be greater than "
+              f"the bootloader's own origin (0x{BOOTLOADER_ORIGIN:08X})", file=sys.stderr)
+        sys.exit(1)
+
+    main(args.bootloader_bin, args.app_bin, args.app_offset, args.reference_uf2, args.output)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,3 +68,32 @@ add_custom_command(
     COMMENT "Generating version"
 )
 add_library(app_version "${SRC_DIRECTORY}/generated/version.c")
+
+
+# OTA firmware update: flash layout constants, computed once in the root
+# CMakeLists.txt (shared with the bootloader target) and consumed here.
+# The app target no longer needs FIRMWARE_UPDATE_APP_REGION_SIZE/OFFSET --
+# it never writes to the app region itself (see src/firmware_update.c); only
+# the bootloader does, since it's the one that actually copies a staged
+# image into place. Kept distinct from the SDK's own PICO_FLASH_SIZE_BYTES
+# macro (see root CMakeLists.txt) to avoid colliding with hardware_flash's
+# bounds-check against the physical flash size.
+# NOTE: values are plain integer literals, not parenthesized expressions --
+# CMake silently drops a compile definition whose value starts with '(' when
+# passing it on the compiler command line (it's misparsed as a function-style
+# macro), so e.g. "(4 * 1024 * 1024)" would never actually reach the compiler.
+# FIRMWARE_UPDATE_BATCH_SIZE: how many bytes are erased+programmed per
+# flash_safe_execute() call during OTA upload. Each call dynamically creates
+# and tears down a max-priority FreeRTOS task on the other core to
+# coordinate the multicore lockout (see pico_flash's flash.c) -- doing that
+# once per 4KB sector for a large image (hundreds of times back to back) was
+# found to wedge the system, so writes are batched into much larger chunks.
+# Sized generously on pico2_w (abundant RAM headroom) and more conservatively
+# on pico_w (tighter RAM budget) -- must remain a multiple of 4096.
+target_compile_definitions("${TARGET_NAME}" PUBLIC
+    FIRMWARE_UPDATE_TOTAL_FLASH_SIZE=${FIRMWARE_UPDATE_TOTAL_FLASH_SIZE}
+    FIRMWARE_UPDATE_STAGING_OFFSET=${FIRMWARE_UPDATE_STAGING_OFFSET}
+    FIRMWARE_UPDATE_STAGING_SIZE=${FIRMWARE_UPDATE_STAGING_SIZE}
+    FIRMWARE_UPDATE_BOARD_TYPE=${FIRMWARE_UPDATE_BOARD_TYPE}
+    FIRMWARE_UPDATE_BATCH_SIZE=${FIRMWARE_UPDATE_BATCH_SIZE}
+)

--- a/src/charge_mode.cpp
+++ b/src/charge_mode.cpp
@@ -707,6 +707,11 @@ bool http_rest_charge_mode_config(struct fs_file *file, int num_params, char *pa
 }
 
 
+bool charge_mode_is_idle(void) {
+    return charge_mode_config.charge_mode_state == CHARGE_MODE_EXIT;
+}
+
+
 bool http_rest_charge_mode_state(struct fs_file *file, int num_params, char *params[], char *values[]) {
     // Mappings
     // s0 (float): Charge weight set point (unitless)

--- a/src/charge_mode.h
+++ b/src/charge_mode.h
@@ -62,6 +62,11 @@ bool charge_mode_config_init(void);
 uint8_t charge_mode_menu(bool charge_mode_skip_user_input);
 bool charge_mode_config_save(void);
 
+// charge_mode_config is a C++ global (charge_mode.cpp) and not directly
+// visible to plain C translation units; used by firmware_update.c to refuse
+// installing a new firmware image while a charge/dispense cycle is active.
+bool charge_mode_is_idle(void);
+
 // REST interface
 bool http_rest_charge_mode_config(struct fs_file *file, int num_params, char *params[], char *values[]);
 bool http_rest_charge_mode_state(struct fs_file *file, int num_params, char *params[], char *values[]);

--- a/src/common.c
+++ b/src/common.c
@@ -92,15 +92,26 @@ const uint32_t crc32_table[256] = {
 0xBDBDF21C,0xCABAC28A,0x53B39330,0x24B4A3A6,0xBAD03605,0xCDD70693,0x54DE5729,0x23D967BF,
 0xB3667A2E,0xC4614AB8,0x5D681B02,0x2A6F2B94,0xB40BBE37,0xC30C8EA1,0x5A05DF1B,0x2D02EF8D
 };
-uint32_t software_crc32(void * data, size_t length) {
+uint32_t software_crc32_init(void) {
+    return 0xffffffff;
+}
+
+uint32_t software_crc32_update(uint32_t crc, const void * data, size_t length) {
     const uint8_t *p = (const uint8_t *)data;
-    uint32_t crc = 0xffffffff;
 
     while (length--) {
         crc = crc32_table[(crc ^ *p++) & 0xFF] ^ (crc >> 8);
     }
 
+    return crc;
+}
+
+uint32_t software_crc32_finalize(uint32_t crc) {
     return crc ^ 0xffffffff;
+}
+
+uint32_t software_crc32(void * data, size_t length) {
+    return software_crc32_finalize(software_crc32_update(software_crc32_init(), data, length));
 }
 
 

--- a/src/common.h
+++ b/src/common.h
@@ -33,6 +33,15 @@ void delay_ms(uint32_t ms, BaseType_t scheduler_state);
 const char * boolean_to_string(bool var);
 bool string_to_boolean(char * s);
 
+uint32_t software_crc32(void * data, size_t length);
+
+// Incremental form of software_crc32(), for computing a CRC32 across data
+// that arrives in chunks (e.g. a streamed network upload) without ever
+// buffering the whole thing in RAM.
+uint32_t software_crc32_init(void);
+uint32_t software_crc32_update(uint32_t crc, const void * data, size_t length);
+uint32_t software_crc32_finalize(uint32_t crc);
+
 int float_to_string(char * output_decimal_str, float var, decimal_places_t decimal_places);
 
 /** 

--- a/src/display.h
+++ b/src/display.h
@@ -10,6 +10,12 @@ extern "C" {
 
 u8g2_t *get_display_handler(void);
 
+// Guards concurrent access to the shared u8g2 buffer/SPI bus: any code that
+// draws to the display (menu_task, firmware_update.c's OTA status screen,
+// etc.) must hold this around its whole ClearBuffer/.../SendBuffer sequence.
+void acquire_display_buffer_access(void);
+void release_display_buffer_access(void);
+
 // REST
 bool http_get_display_buffer(struct fs_file *file, int num_params, char *params[], char *values[]);
 

--- a/src/firmware_footer.h
+++ b/src/firmware_footer.h
@@ -1,0 +1,50 @@
+#ifndef FIRMWARE_FOOTER_H_
+#define FIRMWARE_FOOTER_H_
+
+#include <stdint.h>
+
+
+// On-flash OTA footer, appended to app.bin at build time by
+// scripts/append_firmware_footer.py to produce app_ota.bin. Lives at a fixed
+// address (the last FIRMWARE_FOOTER_SIZE bytes of the OTA staging region),
+// regardless of the uploaded payload's actual size, so "is a valid image
+// staged" is a stateless flash read that survives reboot.
+#define FIRMWARE_FOOTER_MAGIC          0x4B52544FUL
+#define FIRMWARE_FOOTER_FORMAT_VERSION 1
+#define FIRMWARE_FOOTER_VERSION_STRLEN 32
+#define FIRMWARE_FOOTER_HASH_STRLEN    16
+#define FIRMWARE_FOOTER_RESERVED_LEN   60
+#define FIRMWARE_FOOTER_SIZE           128
+
+typedef enum {
+    FIRMWARE_BOARD_TYPE_UNKNOWN = 0,
+    FIRMWARE_BOARD_TYPE_PICO_W  = 1,
+    FIRMWARE_BOARD_TYPE_PICO2_W = 2,
+} firmware_board_type_t;
+
+// reserved[0] is repurposed as an "install pending" flag: the live app sets
+// it (and rewrites footer_crc32) when the user confirms Install, then
+// reboots without touching the app region itself; the second-stage
+// bootloader (bootloader/main.c) is what actually checks this flag, copies
+// the staged image into the app region if set, clears it, and chain-loads
+// into the app. This keeps the footer's size/layout stable across that
+// change -- see the c-style skill's persisted-struct-compatibility rule,
+// applied here to this on-flash struct the same way it applies to EEPROM.
+#define FIRMWARE_FOOTER_INSTALL_PENDING_BYTE 0
+
+typedef struct __attribute__((packed)) {
+    uint32_t magic;                                          // FIRMWARE_FOOTER_MAGIC
+    uint16_t footer_format_version;                          // FIRMWARE_FOOTER_FORMAT_VERSION
+    uint16_t board_type;                                      // firmware_board_type_t
+    uint32_t payload_size;                                    // bytes of app image before this footer
+    uint32_t payload_crc32;                                   // over [0, payload_size)
+    char     version_string[FIRMWARE_FOOTER_VERSION_STRLEN];  // NUL-padded
+    char     vcs_hash[FIRMWARE_FOOTER_HASH_STRLEN];            // NUL-padded
+    uint8_t  reserved[FIRMWARE_FOOTER_RESERVED_LEN];          // reserved[0] = install pending, rest zero-filled
+    uint32_t footer_crc32;                                     // over all preceding footer bytes
+} firmware_update_footer_t;
+
+_Static_assert(sizeof(firmware_update_footer_t) == FIRMWARE_FOOTER_SIZE,
+               "firmware_update_footer_t must be exactly FIRMWARE_FOOTER_SIZE bytes");
+
+#endif  // FIRMWARE_FOOTER_H_

--- a/src/firmware_update.c
+++ b/src/firmware_update.c
@@ -1,0 +1,534 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "pico.h"
+#include "pico/flash.h"
+#include "hardware/flash.h"
+#include "hardware/regs/addressmap.h"
+
+#include "lwip/apps/httpd.h"
+#include "lwip/pbuf.h"
+
+#include "firmware_update.h"
+#include "common.h"
+#include "system_control.h"
+#include "charge_mode.h"
+#include "eeprom.h"
+#include "version.h"
+#include "display.h"
+
+extern eeprom_metadata_t metadata;
+
+#define FIRMWARE_UPDATE_UPLOAD_URI "/rest/firmware_upload"
+#define FIRMWARE_UPDATE_STATUS_URI "/rest/firmware_update_status"
+
+// The last flash sector of the staging region is reserved entirely for the
+// footer (see src/firmware_footer.h) -- payload writes never touch it, so an
+// upload's payload and its footer can never land in the same sector.
+#define FIRMWARE_UPDATE_MAX_PAYLOAD_SIZE (FIRMWARE_UPDATE_STAGING_SIZE - FLASH_SECTOR_SIZE)
+#define FIRMWARE_UPDATE_FOOTER_SECTOR_OFFSET (FIRMWARE_UPDATE_STAGING_OFFSET + FIRMWARE_UPDATE_STAGING_SIZE - FLASH_SECTOR_SIZE)
+#define FIRMWARE_UPDATE_FOOTER_OFFSET (FIRMWARE_UPDATE_STAGING_OFFSET + FIRMWARE_UPDATE_STAGING_SIZE - FIRMWARE_FOOTER_SIZE)
+
+typedef struct {
+    uint32_t flash_offset;   // offset from the start of flash (XIP_BASE)
+    const uint8_t *data;     // exactly `count` bytes
+    size_t count;            // multiple of FLASH_SECTOR_SIZE
+} flash_write_ctx_t;
+
+// Upload/staging state. Single-instance: only one upload can be in flight at
+// a time, matching the reality of a locally-administered device.
+static bool s_upload_in_progress;
+static bool s_last_upload_ok;
+static char s_last_upload_error[64];
+static uint32_t s_content_len;
+static uint32_t s_payload_size;
+static uint32_t s_bytes_received;
+static uint32_t s_running_crc32;
+static uint32_t s_next_write_offset;   // bytes, relative to FIRMWARE_UPDATE_STAGING_OFFSET
+static bool s_write_failed;
+static uint8_t s_batch_buf[FIRMWARE_UPDATE_BATCH_SIZE] __attribute__((aligned(4)));
+static size_t s_batch_buf_fill;
+static uint8_t s_footer_buf[FIRMWARE_FOOTER_SIZE];
+
+
+// Runs with IRQs disabled and the other FreeRTOS core parked (via
+// flash_safe_execute); must not fetch instructions from flash for the
+// duration, so this function and everything it calls must live in RAM.
+//
+// Erases/programs in FLASH_SECTOR_SIZE (4096-byte) steps rather than one
+// call covering the whole (much larger) batch: community reports indicate
+// flash_range_erase can misbehave for erase sizes that don't divide cleanly
+// against the ROM erase routine's internal 64KB block granularity, whereas
+// plain sector-sized calls are well-proven. This keeps the call count (and
+// thus flash_safe_execute/lockout overhead) exactly as reduced as the
+// RAM-side batching already achieves -- only the size of each individual
+// hardware erase/program call changes.
+static void __no_inline_not_in_flash_func(flash_write_batch)(void *param) {
+    flash_write_ctx_t *ctx = (flash_write_ctx_t *)param;
+
+    for (size_t done = 0; done < ctx->count; done += FLASH_SECTOR_SIZE) {
+        flash_range_erase(ctx->flash_offset + done, FLASH_SECTOR_SIZE);
+        flash_range_program(ctx->flash_offset + done, ctx->data + done, FLASH_SECTOR_SIZE);
+    }
+}
+
+
+// Erases and reprograms a batch of consecutive flash sectors in a single
+// flash_safe_execute() call, parking the other FreeRTOS core for the whole
+// batch's duration. Both flash_range_erase/program natively support a count
+// spanning multiple sectors, so no per-sector loop is needed here -- keeping
+// the number of flash_safe_execute calls low matters because each call
+// dynamically creates and tears down a max-priority FreeRTOS task on the
+// other core (see pico_flash's flash.c) to coordinate the lockout; doing
+// that once per 4KB sector for a large image (hundreds of times back to
+// back) was found to wedge the system. data must point to exactly `count`
+// bytes, and count must be a multiple of FLASH_SECTOR_SIZE.
+static bool flash_write_batch_safe(uint32_t flash_offset, const uint8_t *data, size_t count) {
+    flash_write_ctx_t ctx = {
+        .flash_offset = flash_offset,
+        .data = data,
+        .count = count,
+    };
+
+    int rc = flash_safe_execute(flash_write_batch, &ctx, 5000);
+    if (rc != PICO_OK) {
+        printf("firmware_update: flash_safe_execute failed at offset 0x%08lX count %lu, rc=%d\n",
+               (unsigned long)flash_offset, (unsigned long)count, rc);
+        return false;
+    }
+
+    return true;
+}
+
+
+// Flushes the first `count` bytes of the batch buffer to the staging region
+// and advances past them. count must be a multiple of FLASH_SECTOR_SIZE.
+static bool flush_batch_buffer(size_t count) {
+    uint32_t flash_offset = FIRMWARE_UPDATE_STAGING_OFFSET + s_next_write_offset;
+    bool is_ok = flash_write_batch_safe(flash_offset, s_batch_buf, count);
+
+    s_next_write_offset += count;
+    s_batch_buf_fill = 0;
+
+    return is_ok;
+}
+
+
+// Draws live OTA progress to the physical LCD, following the same layout
+// convention as wireless.c's status screen (title/rule/status lines). This
+// is a diagnostic aid: since no serial console is available, whatever is
+// last drawn here remains visible on screen if the device ever hangs,
+// giving a snapshot of exactly how far the process got. Runs from the
+// network/httpd context, concurrently with menu_task's own redraws on the
+// other core -- both sides take display_buffer_access_mutex (see
+// src/display.c) around their draw sequence so they can't interleave on the
+// shared u8g2 buffer and SPI bus.
+static void draw_ota_status(const char *phase, uint32_t bytes_done, uint32_t bytes_total, const char *error) {
+    u8g2_t *display_handler = get_display_handler();
+    char progress_line[24];
+
+    snprintf(progress_line, sizeof(progress_line), "%lu / %lu B", (unsigned long)bytes_done, (unsigned long)bytes_total);
+
+    acquire_display_buffer_access();
+
+    u8g2_ClearBuffer(display_handler);
+
+    u8g2_SetFont(display_handler, u8g2_font_helvB08_tr);
+    u8g2_DrawStr(display_handler, 5, 10, "Firmware Update");
+
+    u8g2_DrawHLine(display_handler, 0, 13, u8g2_GetDisplayWidth(display_handler));
+
+    u8g2_SetFont(display_handler, u8g2_font_6x12_tf);
+    u8g2_DrawStr(display_handler, 5, 23, phase);
+    u8g2_DrawStr(display_handler, 5, 33, progress_line);
+
+    if (error != NULL && error[0] != '\0') {
+        u8g2_DrawStr(display_handler, 5, 43, error);
+    }
+
+    u8g2_SendBuffer(display_handler);
+
+    release_display_buffer_access();
+}
+
+
+static uint32_t compute_footer_crc32(const firmware_update_footer_t *footer) {
+    uint32_t crc = software_crc32_init();
+    crc = software_crc32_update(crc, footer, FIRMWARE_FOOTER_SIZE - sizeof(uint32_t));
+    return software_crc32_finalize(crc);
+}
+
+
+void firmware_update_init(void) {
+    s_upload_in_progress = false;
+    s_last_upload_ok = false;
+    s_last_upload_error[0] = '\0';
+}
+
+
+bool firmware_update_get_staged_info(firmware_update_footer_t *out) {
+    const firmware_update_footer_t *footer =
+        (const firmware_update_footer_t *)(XIP_BASE + FIRMWARE_UPDATE_FOOTER_OFFSET);
+
+    if (footer->magic != FIRMWARE_FOOTER_MAGIC) {
+        return false;
+    }
+
+    if (compute_footer_crc32(footer) != footer->footer_crc32) {
+        return false;
+    }
+
+    memcpy(out, footer, sizeof(firmware_update_footer_t));
+    return true;
+}
+
+
+// Install no longer copies anything into the app region live -- two earlier
+// attempts at making that self-overwrite safe under FreeRTOS (per-batch
+// flash_safe_execute, then one atomic whole-image flash_safe_execute) each
+// bricked the device, the second for reasons that resisted diagnosis without
+// serial debugging. The actual copy now happens in the second-stage
+// bootloader (bootloader/main.c), which runs before FreeRTOS, WiFi, or the
+// second core ever start -- eliminating the multicore/self-overwrite hazard
+// entirely rather than trying to make it safe under a live RTOS.
+//
+// This function's only job is to flip the footer's install-pending flag
+// (see FIRMWARE_FOOTER_INSTALL_PENDING_BYTE in firmware_footer.h) and
+// reboot. It never touches the app region -- only the staging region's
+// already-proven-safe footer sector, via the same flash_write_batch_safe()
+// the upload path already uses to commit the footer. A power loss between
+// this write and the bootloader completing its copy is safe: the bootloader
+// retries the copy from scratch on the next boot until it fully succeeds,
+// only then clearing the flag.
+bool firmware_update_install_and_reboot(void) {
+    firmware_update_footer_t footer;
+    if (!firmware_update_get_staged_info(&footer)) {
+        return false;
+    }
+
+    footer.reserved[FIRMWARE_FOOTER_INSTALL_PENDING_BYTE] = 1;
+    footer.footer_crc32 = compute_footer_crc32(&footer);
+
+    memset(s_batch_buf, 0xFF, FLASH_SECTOR_SIZE);
+    memcpy(&s_batch_buf[FLASH_SECTOR_SIZE - FIRMWARE_FOOTER_SIZE], &footer, FIRMWARE_FOOTER_SIZE);
+
+    if (!flash_write_batch_safe(FIRMWARE_UPDATE_FOOTER_SECTOR_OFFSET, s_batch_buf, FLASH_SECTOR_SIZE)) {
+        draw_ota_status("Install FAILED", 0, footer.payload_size, "Could not mark install pending");
+        return false;
+    }
+
+    draw_ota_status("Rebooting...", footer.payload_size, footer.payload_size, NULL);
+
+    // Does not return on success -- mirrors the existing s5/software_reset
+    // precedent in system_control.c, which also reboots before delivering a
+    // response.
+    software_reboot();
+    return true;
+}
+
+
+err_t httpd_post_begin(void *connection, const char *uri, const char *http_request,
+                        u16_t http_request_len, int content_len, char *response_uri,
+                        u16_t response_uri_len, u8_t *post_auto_wnd) {
+    (void)http_request;
+    (void)http_request_len;
+
+    if (strcmp(uri, FIRMWARE_UPDATE_UPLOAD_URI) != 0) {
+        return ERR_ARG;
+    }
+
+    if (s_upload_in_progress) {
+        s_last_upload_ok = false;
+        snprintf(s_last_upload_error, sizeof(s_last_upload_error), "Upload already in progress");
+        snprintf(response_uri, response_uri_len, "%s", FIRMWARE_UPDATE_STATUS_URI);
+        return ERR_ARG;
+    }
+
+    if (content_len <= (int)FIRMWARE_FOOTER_SIZE ||
+        ((uint32_t)content_len - FIRMWARE_FOOTER_SIZE) > FIRMWARE_UPDATE_MAX_PAYLOAD_SIZE) {
+        s_last_upload_ok = false;
+        snprintf(s_last_upload_error, sizeof(s_last_upload_error), "Image too large or too small for staging region");
+        snprintf(response_uri, response_uri_len, "%s", FIRMWARE_UPDATE_STATUS_URI);
+        return ERR_ARG;
+    }
+
+    s_content_len = (uint32_t)content_len;
+    s_payload_size = s_content_len - FIRMWARE_FOOTER_SIZE;
+    s_bytes_received = 0;
+    s_running_crc32 = software_crc32_init();
+    s_next_write_offset = 0;
+    s_batch_buf_fill = 0;
+    s_write_failed = false;
+    s_upload_in_progress = true;
+
+    // Manual window: we ack (httpd_post_data_recved) every sector's worth of
+    // data as it's copied out of the pbuf, independent of the (larger)
+    // flash-write batch boundary -- see the ack-cadence comment in
+    // httpd_post_receive_data for why this must not be gated on a full
+    // batch completing.
+    *post_auto_wnd = 0;
+
+    draw_ota_status("Uploading...", 0, s_payload_size, NULL);
+
+    return ERR_OK;
+}
+
+
+// httpd_post_data_recved()'s recved_len is a u16_t (max 65535), but
+// FIRMWARE_UPDATE_BATCH_SIZE can exceed that (e.g. 128KB on pico2_w) --
+// acking the full amount in one call would silently truncate/overflow to a
+// wrong value. Ack in <=65535-byte chunks instead.
+static void post_data_recved_all(void *connection, uint32_t total) {
+    while (total > 0) {
+        u16_t chunk = (total > 0xFFFFu) ? 0xFFFFu : (u16_t)total;
+        httpd_post_data_recved(connection, chunk);
+        total -= chunk;
+    }
+}
+
+
+err_t httpd_post_receive_data(void *connection, struct pbuf *p) {
+    for (struct pbuf *q = p; q != NULL; q = q->next) {
+        uint32_t q_start = s_bytes_received;
+        uint32_t q_end = q_start + q->len;
+        const uint8_t *q_data = (const uint8_t *)q->payload;
+
+        if (q_start < s_payload_size) {
+            uint32_t payload_end_in_q = (q_end < s_payload_size) ? q_end : s_payload_size;
+            uint32_t remaining = payload_end_in_q - q_start;
+            const uint8_t *src = q_data;
+
+            while (remaining > 0) {
+                // Ack cadence is intentionally decoupled from flash-write
+                // batch size: acking only happens at FIRMWARE_UPDATE_BATCH_SIZE
+                // boundaries (32-128KB) deadlocks, because this project's TCP
+                // receive window (TCP_WND, ~11.4KB) is smaller than one batch
+                // -- the window closes before a batch ever completes, and
+                // nothing would ever ack it open again. So each copy is
+                // capped at one flash sector, and acked immediately once
+                // copied; only the (larger) flash write itself is batched.
+                size_t space_to_sector_boundary = FLASH_SECTOR_SIZE - (s_batch_buf_fill % FLASH_SECTOR_SIZE);
+                size_t space_in_batch = FIRMWARE_UPDATE_BATCH_SIZE - s_batch_buf_fill;
+                size_t chunk = remaining;
+                if (chunk > space_to_sector_boundary) {
+                    chunk = space_to_sector_boundary;
+                }
+                if (chunk > space_in_batch) {
+                    chunk = space_in_batch;
+                }
+
+                memcpy(&s_batch_buf[s_batch_buf_fill], src, chunk);
+                s_running_crc32 = software_crc32_update(s_running_crc32, src, chunk);
+                s_batch_buf_fill += chunk;
+                src += chunk;
+                remaining -= chunk;
+
+                // Ack the bytes we just copied out of the pbuf right away --
+                // this only signals "consumed from the network", not "safely
+                // on flash", so it's correct regardless of whether a flash
+                // write happens below.
+                post_data_recved_all(connection, chunk);
+
+                // Diagnostic checkpoint: if the device hangs again, whatever
+                // was last drawn here shows exactly how far the upload got.
+                draw_ota_status("Uploading...", s_next_write_offset + s_batch_buf_fill, s_payload_size, NULL);
+
+                if (s_batch_buf_fill == FIRMWARE_UPDATE_BATCH_SIZE) {
+                    // Once a write has failed, the staged image is already
+                    // invalid -- stop attempting further flash writes (each
+                    // one is expensive/risky), but keep draining incoming
+                    // bytes so the connection completes normally and
+                    // httpd_post_finished can report a clean error.
+                    if (!s_write_failed) {
+                        if (!flush_batch_buffer(FIRMWARE_UPDATE_BATCH_SIZE)) {
+                            s_write_failed = true;
+                        }
+                    } else {
+                        s_batch_buf_fill = 0;
+                    }
+                }
+            }
+        }
+
+        if (q_end > s_payload_size) {
+            uint32_t footer_start_in_q = (q_start > s_payload_size) ? q_start : s_payload_size;
+            uint32_t footer_bytes = q_end - footer_start_in_q;
+            const uint8_t *src = q_data + (footer_start_in_q - q_start);
+            uint32_t footer_offset = footer_start_in_q - s_payload_size;
+
+            memcpy(&s_footer_buf[footer_offset], src, footer_bytes);
+            post_data_recved_all(connection, footer_bytes);
+        }
+
+        s_bytes_received = q_end;
+    }
+
+    pbuf_free(p);
+    return ERR_OK;
+}
+
+
+void httpd_post_finished(void *connection, char *response_uri, u16_t response_uri_len) {
+    (void)connection;
+
+    if (!s_write_failed && s_batch_buf_fill > 0) {
+        size_t padded = ((s_batch_buf_fill + FLASH_SECTOR_SIZE - 1) / FLASH_SECTOR_SIZE) * FLASH_SECTOR_SIZE;
+        memset(&s_batch_buf[s_batch_buf_fill], 0xFF, padded - s_batch_buf_fill);
+        if (!flush_batch_buffer(padded)) {
+            s_write_failed = true;
+        }
+    }
+
+    firmware_update_footer_t received_footer;
+    memcpy(&received_footer, s_footer_buf, sizeof(received_footer));
+
+    bool is_valid = true;
+    s_last_upload_error[0] = '\0';
+
+    if (s_write_failed) {
+        is_valid = false;
+        snprintf(s_last_upload_error, sizeof(s_last_upload_error), "Flash write failed during upload");
+    } else if (s_bytes_received != s_content_len) {
+        is_valid = false;
+        snprintf(s_last_upload_error, sizeof(s_last_upload_error), "Incomplete upload");
+    } else if (received_footer.magic != FIRMWARE_FOOTER_MAGIC) {
+        is_valid = false;
+        snprintf(s_last_upload_error, sizeof(s_last_upload_error), "Bad footer magic");
+    } else if (compute_footer_crc32(&received_footer) != received_footer.footer_crc32) {
+        is_valid = false;
+        snprintf(s_last_upload_error, sizeof(s_last_upload_error), "Footer CRC mismatch");
+    } else if (received_footer.board_type != FIRMWARE_UPDATE_BOARD_TYPE) {
+        is_valid = false;
+        snprintf(s_last_upload_error, sizeof(s_last_upload_error), "Wrong board type");
+    } else if (received_footer.payload_size != s_payload_size) {
+        is_valid = false;
+        snprintf(s_last_upload_error, sizeof(s_last_upload_error), "Payload size mismatch");
+    } else if (software_crc32_finalize(s_running_crc32) != received_footer.payload_crc32) {
+        is_valid = false;
+        snprintf(s_last_upload_error, sizeof(s_last_upload_error), "Payload CRC mismatch");
+    }
+
+    if (is_valid) {
+        // Commit the footer to its fixed flash slot (the tail of the
+        // reserved last sector) so firmware_update_get_staged_info() can
+        // find it, including after a reboot.
+        memset(s_batch_buf, 0xFF, FLASH_SECTOR_SIZE);
+        memcpy(&s_batch_buf[FLASH_SECTOR_SIZE - FIRMWARE_FOOTER_SIZE], s_footer_buf, FIRMWARE_FOOTER_SIZE);
+        is_valid = flash_write_batch_safe(FIRMWARE_UPDATE_FOOTER_SECTOR_OFFSET, s_batch_buf, FLASH_SECTOR_SIZE);
+        if (!is_valid) {
+            snprintf(s_last_upload_error, sizeof(s_last_upload_error), "Failed to commit footer to flash");
+        }
+    }
+
+    s_last_upload_ok = is_valid;
+    s_upload_in_progress = false;
+
+    draw_ota_status(is_valid ? "Upload OK" : "Upload FAILED",
+                     s_bytes_received, s_content_len,
+                     is_valid ? NULL : s_last_upload_error);
+
+    snprintf(response_uri, response_uri_len, "%s", FIRMWARE_UPDATE_STATUS_URI);
+}
+
+
+bool http_rest_firmware_update_status(struct fs_file *file, int num_params, char *params[], char *values[]) {
+    static char json_buffer[640];
+
+    firmware_update_footer_t staged;
+    bool staged_valid = firmware_update_get_staged_info(&staged);
+
+    char staged_version[FIRMWARE_FOOTER_VERSION_STRLEN + 1] = {0};
+    char staged_hash[FIRMWARE_FOOTER_HASH_STRLEN + 1] = {0};
+    uint32_t staged_payload_size = 0;
+
+    if (staged_valid) {
+        memcpy(staged_version, staged.version_string, FIRMWARE_FOOTER_VERSION_STRLEN);
+        memcpy(staged_hash, staged.vcs_hash, FIRMWARE_FOOTER_HASH_STRLEN);
+        staged_payload_size = staged.payload_size;
+    }
+
+    // upload_in_progress/bytes_received/content_len/bytes_written reflect
+    // either the currently in-flight upload, or the last completed one --
+    // useful for polling from a separate browser tab to see live progress
+    // (or exactly how far a stalled upload got) without any serial console.
+    snprintf(json_buffer, sizeof(json_buffer),
+             "%s"
+             "{\"s0\":\"%s\",\"s1\":\"%s\",\"s2\":\"%s\",\"s3\":\"%s\","
+             "\"staged_valid\":%s,\"staged_version_string\":\"%s\",\"staged_vcs_hash\":\"%s\","
+             "\"staged_payload_size\":%lu,\"last_upload_ok\":%s,\"last_upload_error\":\"%s\","
+             "\"upload_in_progress\":%s,\"bytes_received\":%lu,\"content_len\":%lu,\"bytes_written\":%lu}",
+             http_json_header,
+             metadata.unique_id, version_string, vcs_hash, build_type,
+             boolean_to_string(staged_valid), staged_version, staged_hash,
+             (unsigned long)staged_payload_size,
+             boolean_to_string(s_last_upload_ok), s_last_upload_error,
+             boolean_to_string(s_upload_in_progress),
+             (unsigned long)s_bytes_received, (unsigned long)s_content_len,
+             (unsigned long)s_next_write_offset);
+
+    size_t data_length = strlen(json_buffer);
+    file->data = json_buffer;
+    file->len = data_length;
+    file->index = data_length;
+    file->flags = FS_FILE_FLAGS_HEADER_INCLUDED;
+
+    return true;
+}
+
+
+bool http_rest_firmware_install(struct fs_file *file, int num_params, char *params[], char *values[]) {
+    // Mappings
+    // i0 (bool): confirm install
+    static char json_buffer[128];
+
+    bool confirm_flag = false;
+    for (int idx = 0; idx < num_params; idx += 1) {
+        if (strcmp(params[idx], "i0") == 0) {
+            confirm_flag = string_to_boolean(values[idx]);
+        }
+    }
+
+    const char *error_reason = NULL;
+    firmware_update_footer_t staged;
+
+    if (!confirm_flag) {
+        error_reason = "Install not confirmed";
+    } else if (!charge_mode_is_idle()) {
+        error_reason = "Charge cycle is active";
+    } else if (!firmware_update_get_staged_info(&staged)) {
+        error_reason = "No valid staged image";
+    }
+
+    if (error_reason != NULL) {
+        snprintf(json_buffer, sizeof(json_buffer), "%s{\"error\":\"%s\"}", http_json_header, error_reason);
+
+        size_t data_length = strlen(json_buffer);
+        file->data = json_buffer;
+        file->len = data_length;
+        file->index = data_length;
+        file->flags = FS_FILE_FLAGS_HEADER_INCLUDED;
+
+        return true;
+    }
+
+    // Does not return on success -- marks the image pending and reboots;
+    // the bootloader does the actual flash copy on the next boot (see
+    // firmware_update_install_and_reboot()'s own comment), mirroring the
+    // existing s5/software_reset precedent (no clean response is delivered
+    // on the success path).
+    firmware_update_install_and_reboot();
+
+    // Only reached if the install failed unexpectedly (e.g. a flash write
+    // error marking the pending flag) after passing the checks above.
+    snprintf(json_buffer, sizeof(json_buffer), "%s{\"error\":\"Install failed\"}", http_json_header);
+
+    size_t data_length = strlen(json_buffer);
+    file->data = json_buffer;
+    file->len = data_length;
+    file->index = data_length;
+    file->flags = FS_FILE_FLAGS_HEADER_INCLUDED;
+
+    return true;
+}

--- a/src/firmware_update.c
+++ b/src/firmware_update.c
@@ -229,6 +229,23 @@ bool firmware_update_install_and_reboot(void) {
 }
 
 
+// Erases just the footer sector, so firmware_update_get_staged_info() stops
+// reporting a valid staged image until a new upload completes and commits a
+// fresh footer. Called at the start of every new upload attempt, before any
+// data is received, so: (1) a previously-installed version's footer doesn't
+// keep being reported as "staged" forever (see the bootloader's own
+// invalidate_staged_image(), which handles the post-install case; this
+// handles the pre-upload case), and (2) if this new upload turns out to be
+// invalid, the status correctly shows the rejection reason instead of the
+// old (now superseded) image, so the user can immediately retry with a
+// different file rather than being stuck looking at stale "ready to
+// install" state.
+static bool invalidate_staged_footer(void) {
+    memset(s_batch_buf, 0xFF, FLASH_SECTOR_SIZE);
+    return flash_write_batch_safe(FIRMWARE_UPDATE_FOOTER_SECTOR_OFFSET, s_batch_buf, FLASH_SECTOR_SIZE);
+}
+
+
 err_t httpd_post_begin(void *connection, const char *uri, const char *http_request,
                         u16_t http_request_len, int content_len, char *response_uri,
                         u16_t response_uri_len, u8_t *post_auto_wnd) {
@@ -250,6 +267,13 @@ err_t httpd_post_begin(void *connection, const char *uri, const char *http_reque
         ((uint32_t)content_len - FIRMWARE_FOOTER_SIZE) > FIRMWARE_UPDATE_MAX_PAYLOAD_SIZE) {
         s_last_upload_ok = false;
         snprintf(s_last_upload_error, sizeof(s_last_upload_error), "Image too large or too small for staging region");
+        snprintf(response_uri, response_uri_len, "%s", FIRMWARE_UPDATE_STATUS_URI);
+        return ERR_ARG;
+    }
+
+    if (!invalidate_staged_footer()) {
+        s_last_upload_ok = false;
+        snprintf(s_last_upload_error, sizeof(s_last_upload_error), "Failed to clear previous staged image");
         snprintf(response_uri, response_uri_len, "%s", FIRMWARE_UPDATE_STATUS_URI);
         return ERR_ARG;
     }

--- a/src/firmware_update.h
+++ b/src/firmware_update.h
@@ -1,0 +1,35 @@
+#ifndef FIRMWARE_UPDATE_H_
+#define FIRMWARE_UPDATE_H_
+
+#include <lwip/apps/fs.h>
+
+#include "firmware_footer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void firmware_update_init(void);
+
+// Reads and validates the fixed footer slot at the end of the OTA staging
+// region directly from flash. Returns false if no valid image is staged
+// (magic mismatch or footer_crc32 mismatch).
+bool firmware_update_get_staged_info(firmware_update_footer_t *out);
+
+// Marks the validated staged image as pending install (a flag in the
+// footer's reserved bytes, staging region only -- never touches the app
+// region itself) and reboots. The second-stage bootloader
+// (bootloader/main.c) is what actually copies the image into the app
+// region on the next boot. Returns false if there is no valid staged image
+// or the flag couldn't be written; does not return on success.
+bool firmware_update_install_and_reboot(void);
+
+// REST interface
+bool http_rest_firmware_update_status(struct fs_file *file, int num_params, char *params[], char *values[]);
+bool http_rest_firmware_install(struct fs_file *file, int num_params, char *params[], char *values[]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // FIRMWARE_UPDATE_H_

--- a/src/html/web_portal.html
+++ b/src/html/web_portal.html
@@ -754,10 +754,62 @@
 
                     </section>
 
+                    <!-- Update Firmware Page -->
+                    <section class="settings-page" id="settings-update-firmware" name="Update Firmware" style="display: none;">
+                        <!-- Not a <form>: onSettingsLinkClicked's generic fetch-and-fill only
+                             triggers for a section that contains one, and this page's fields
+                             are instead populated by refreshFirmwareStatus() -- a single fetch
+                             shared by the nav click and the post-upload refresh, rather than
+                             two independent fetches to the same endpoint. -->
+                        <div id="firmwareUpdateFields" class="grid grid-cols-1 gap-3">
+                            <div class="grid grid-cols-1 gap-1">
+                                <span class="label-text">Unique ID</span>
+                                <input type="text" class="input input-bordered" name="s0" disabled="disabled" readonly>
+                            </div>
+
+                            <div class="grid grid-cols-1 gap-1">
+                                <span class="label-text">Firmware Version</span>
+                                <input type="text" class="input input-bordered" name="s1" disabled="disabled" readonly>
+                            </div>
+
+                            <div class="grid grid-cols-1 gap-1">
+                                <span class="label-text">VCS Hash</span>
+                                <input type="text" class="input input-bordered" name="s2" disabled="disabled" readonly>
+                            </div>
+
+                            <div class="grid grid-cols-1 gap-1">
+                                <span class="label-text">Build Type</span>
+                                <input type="text" class="input input-bordered" name="s3" disabled="disabled" readonly>
+                            </div>
+
+                            <div class="divider"></div>
+
+                            <div class="grid grid-cols-1 gap-1">
+                                <span class="label-text">Staged Image Version</span>
+                                <input type="text" class="input input-bordered" name="staged_version_string" disabled="disabled" readonly>
+                            </div>
+
+                            <div class="grid grid-cols-1 gap-1">
+                                <span class="label-text">Staged Image Status</span>
+                                <input type="text" class="input input-bordered" id="firmwareStagedStatusText" disabled="disabled" readonly>
+                            </div>
+                        </div>
+
+                        <div class="divider"></div>
+
+                        <div class="grid grid-cols-1 gap-2">
+                            <span class="label-text">Upload Firmware (.bin)</span>
+                            <input type="file" id="firmwareFileInput" class="file-input file-input-bordered" accept=".bin">
+                            <progress id="firmwareUploadProgress" class="progress progress-primary w-full" value="0" max="100" style="display: none;"></progress>
+
+                            <button class="btn btn-neutral" id="firmwareInstallBtn" disabled>Install</button>
+                        </div>
+                    </section>
+
                 </div>
-            </div> 
+            </div>
             <div class="drawer-side exclude-bottom-nav">
-                <label id="closeDrawerSide" for="settingsDrawer" aria-label="close sidebar" class="drawer-overlay"></label> 
+                <label id="closeDrawerSide" for="settingsDrawer" aria-label="close sidebar" class="drawer-overlay"></label>
                 <ul id=drawerSlide" class="menu p-2 w-60 min-h-full bg-base-200">
                     <!-- Sidebar content here -->
                     <li><a class="text-lg" onclick="onSettingsLinkClicked('settings-scale')">Scale</a></li>
@@ -770,6 +822,7 @@
                     <li><a class="text-lg" onclick="onSettingsLinkClicked('settings-mini-12864-module')">Mini 12864 Module</a></li>
                     <li><a class="text-lg" onclick="onSettingsLinkClicked('settings-servo-gate')">Servo Gate</a></li>
                     <li><a class="text-lg" onclick="onSettingsLinkClicked('settings-system-control')">System Control</a></li>
+                    <li><a class="text-lg" onclick="onSettingsLinkClicked('settings-update-firmware'); refreshFirmwareStatus();">Update Firmware</a></li>
                 </ul>
             </div>
         </div>
@@ -896,6 +949,24 @@
     <form method="dialog" class="modal-backdrop">
         <button>close</button>
     </form>
+</dialog>
+
+<dialog id="confirmFirmwareInstallDialog" class="modal modal-bottom sm:modal-middle">
+    <div class="modal-box">
+        <div class="grid grid-cols-1 gap-2">
+            <h3 class="font-bold text-lg">Install Firmware</h3>
+            <p class="py-4">The device will flash the staged image and reboot. If power is lost during this process, the device will need to be recovered manually via USB BOOTSEL. This action cannot be undone. Continue?</p>
+        </div>
+        <div class="modal-action">
+            <form method="dialog">
+                <!-- if there is a button in form, it will close the modal -->
+                <div class="grid grid-cols-2 gap-2">
+                    <button id="dialogFirmwareInstallConfirmButton" class="btn btn-error">Install &amp; Reboot</button>
+                    <button class="btn">Cancel</button>
+                </div>
+            </form>
+        </div>
+    </div>
 </dialog>
 
 <dialog id="settingsRestoreFailedDialog" class="modal">
@@ -1772,6 +1843,88 @@
         }
         input.click();
     }
+
+    // Single source of truth for the Update Firmware page: one fetch to
+    // /rest/firmware_update_status, used by both the nav-link click and the
+    // post-upload refresh. Populates the raw fields (s0-s3,
+    // staged_version_string) the same way onSettingsLinkClicked's generic
+    // fetch-and-fill does for other settings pages, plus the derived status
+    // text/Install button state that has no single matching JSON key.
+    function refreshFirmwareStatus() {
+        fetch("/rest/firmware_update_status")
+        .then(response => response.json())
+        .then(data => {
+            const fields = document.getElementById("firmwareUpdateFields");
+            for (const key in data) {
+                const element = fields.querySelector('[name="' + key + '"]');
+                if (element) {
+                    element.value = String(data[key]);
+                }
+            }
+
+            const statusText = document.getElementById("firmwareStagedStatusText");
+            const installBtn = document.getElementById("firmwareInstallBtn");
+
+            if (data.staged_valid) {
+                statusText.value = "Valid image staged, ready to install";
+                installBtn.disabled = false;
+            } else if (data.last_upload_error) {
+                statusText.value = "Rejected: " + data.last_upload_error;
+                installBtn.disabled = true;
+            } else {
+                statusText.value = "No image staged";
+                installBtn.disabled = true;
+            }
+        });
+    }
+
+    // Upload the selected firmware file as a raw octet-stream POST body,
+    // with a progress bar driven by XMLHttpRequest's upload.onprogress
+    // (fetch has no equivalent upload-progress event in this browser target).
+    document.getElementById("firmwareFileInput").addEventListener("change", (event) => {
+        const file = event.target.files[0];
+        if (!file) {
+            return;
+        }
+
+        const progress = document.getElementById("firmwareUploadProgress");
+        progress.style.display = "block";
+        progress.value = 0;
+
+        const xhr = new XMLHttpRequest();
+        xhr.open("POST", "/rest/firmware_upload");
+        xhr.setRequestHeader("Content-Type", "application/octet-stream");
+
+        xhr.upload.onprogress = (progressEvent) => {
+            if (progressEvent.lengthComputable) {
+                progress.value = (progressEvent.loaded / progressEvent.total) * 100;
+            }
+        };
+
+        xhr.onloadend = () => {
+            progress.style.display = "none";
+            refreshFirmwareStatus();
+        };
+
+        xhr.send(file);
+    });
+
+    // Confirm, then trigger install -- the device reboots on success, so the
+    // request's connection dropping is the expected outcome, not an error.
+    document.getElementById("firmwareInstallBtn").addEventListener("click", (event) => {
+        event.preventDefault();
+
+        const dialog = document.getElementById("confirmFirmwareInstallDialog");
+        const confirmButton = document.getElementById("dialogFirmwareInstallConfirmButton");
+
+        confirmButton.onclick = function() {
+            fetch("/rest/firmware_install?i0=true").catch(() => {
+                // Expected: the device reboots and drops the connection.
+            });
+        };
+
+        dialog.showModal();
+    });
 
     // Start the long polling process when the page loads
     if (document.readyState != "loading") {

--- a/src/http_rest.c
+++ b/src/http_rest.c
@@ -177,7 +177,7 @@ static char httpd_req_buf[LWIP_HTTPD_MAX_REQ_LENGTH + 1];
 #if LWIP_HTTPD_URI_BUF_LEN
 /* Filename for response file to send when POST is finished or
  * search for default files when a directory is requested. */
-// static char http_uri_buf[LWIP_HTTPD_URI_BUF_LEN + 1];
+static char http_uri_buf[LWIP_HTTPD_URI_BUF_LEN + 1];
 #endif
 
 #if LWIP_HTTPD_DYNAMIC_HEADERS

--- a/src/lwipopts.h
+++ b/src/lwipopts.h
@@ -27,7 +27,8 @@
 
 // Lwip features
 #define LWIP_HTTPD_CGI                  1    // Enable HTTPCGI
-#define LWIP_HTTPD_SUPPORT_POST         0    // Enable POST
+#define LWIP_HTTPD_SUPPORT_POST         1    // Enable POST (firmware OTA upload)
+#define LWIP_HTTPD_POST_MANUAL_WND      1    // Pace TCP window to flash write throughput
 #define LWIP_HTTPD_CUSTOM_FILES         0   
 #define LWIP_HTTPD_DYNAMIC_FILE_READ    0
 #define LWIP_HTTPD_DYNAMIC_HEADERS      0

--- a/src/menu.c
+++ b/src/menu.c
@@ -39,9 +39,11 @@ void menu_task(void *p){
     mui_GotoForm(&mui, 1, 0);
 
     // Render the menu before user input
+    acquire_display_buffer_access();
     u8g2_ClearBuffer(display_handler);
     mui_Draw(&mui);
     u8g2_SendBuffer(display_handler);
+    release_display_buffer_access();
 
     while (true) {
         if (mui_IsFormActive(&mui)) {
@@ -97,8 +99,10 @@ void menu_task(void *p){
             mui_GotoForm(&mui, exit_form_id, 0);
         }
 
+        acquire_display_buffer_access();
         u8g2_ClearBuffer(display_handler);
         mui_Draw(&mui);
         u8g2_SendBuffer(display_handler);
+        release_display_buffer_access();
     }
 }

--- a/src/rest_endpoints.c
+++ b/src/rest_endpoints.c
@@ -14,6 +14,7 @@
 #include "cleanup_mode.h"
 #include "servo_gate.h"
 #include "system_control.h"
+#include "firmware_update.h"
 
 // Generated headers by html2header.py under scripts
 #include "display_mirror.html.h"
@@ -71,6 +72,8 @@ bool http_wizard(struct fs_file *file, int num_params, char *params[], char *val
 
 
 bool rest_endpoints_init(bool default_wizard) {
+    firmware_update_init();
+
     if (default_wizard) {
         rest_register_handler("/", http_wizard);
     }
@@ -97,6 +100,8 @@ bool rest_endpoints_init(bool default_wizard) {
     rest_register_handler("/rest/profile_summary", http_rest_profile_summary);
     rest_register_handler("/rest/servo_gate_state", http_rest_servo_gate_state);
     rest_register_handler("/rest/servo_gate_config", http_rest_servo_gate_config);
+    rest_register_handler("/rest/firmware_update_status", http_rest_firmware_update_status);
+    rest_register_handler("/rest/firmware_install", http_rest_firmware_install);
     rest_register_handler("/display_buffer", http_get_display_buffer);
     rest_register_handler("/display_mirror", http_display_mirror);
 

--- a/tests/web_test.py
+++ b/tests/web_test.py
@@ -10,7 +10,7 @@ Dependencies from pip:
 """
 
 import json
-from flask import Flask, send_from_directory
+from flask import Flask, request, send_from_directory
 import os
 
 
@@ -121,6 +121,42 @@ def rest_servo_gate_config():
 @app.route('/rest/system_control')
 def rest_system_control():
     return {"s0":"8381FFF","s1":"1.2.10-dirty","s2":"8f201d6","s3":"Debug","s4":False,"s5":False,"s6":False}
+
+
+firmware_staged_valid = False
+
+@app.route('/rest/firmware_update_status')
+def rest_firmware_update_status():
+    return {"s0":"8381FFF","s1":"1.2.10-dirty","s2":"8f201d6","s3":"Debug",
+            "staged_valid": firmware_staged_valid,
+            "staged_version_string": "1.2.11-dirty" if firmware_staged_valid else "",
+            "staged_vcs_hash": "abcdef1" if firmware_staged_valid else "",
+            "staged_payload_size": 700000 if firmware_staged_valid else 0,
+            "last_upload_ok": firmware_staged_valid,
+            "last_upload_error": ""}
+
+
+@app.route('/rest/firmware_upload', methods=['POST'])
+def rest_firmware_upload():
+    global firmware_staged_valid
+    # Real device validates magic/CRC/board-type; this stub just pretends
+    # any upload with a body succeeds, so the web UI can be developed without
+    # hardware.
+    firmware_staged_valid = len(request.get_data()) > 0
+    return rest_firmware_update_status()
+
+
+@app.route('/rest/firmware_install')
+def rest_firmware_install():
+    global firmware_staged_valid
+    if request.args.get('i0') != 'true':
+        return {"error": "Install not confirmed"}
+    if not firmware_staged_valid:
+        return {"error": "No valid staged image"}
+    # A real device reboots here without responding; the stub just resets
+    # the staged flag so the page reflects "installed" on next refresh.
+    firmware_staged_valid = False
+    return {"s0":"8381FFF","s1":"1.2.11-dirty","s2":"abcdef1","s3":"Debug"}
 
 
 @app.route("/")


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h3 style="color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Adds over-the-air firmware updates through the web UI, so future firmware can be installed without a physical BOOTSEL reflash. Implements this via a small, dedicated second-stage bootloader that runs on every boot — the actual flash copy that applies an update happens there, not in the live FreeRTOS app, which avoids the app having to overwrite its own running flash region.</p><h3 style="color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Why</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Physical BOOTSEL flashing requires a cable and hands-on access to the device. Attempts to let the <em>running</em> app copy a new image into its own flash region live (under FreeRTOS, with a second core active) proved unsafe and bricked test hardware — flash writes racing against code still executing from the same region is a real hazard on RP2040/RP2350. The fix is architectural: move the copy into a minimal, single-threaded bootloader stage that runs <em>before</em> FreeRTOS, networking, or the second core ever start, so there's nothing else around to race against.</p><h3 style="color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">How it works</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Flash is split into three regions:</p>
Region | Contents
-- | --
0x10000000, 64 KiB | The bootloader (bootloader/main.c)
Right after it | The app (this firmware)
Upper half of the chip | OTA staging area (uploaded images land here first)

<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">On every boot, the bootloader checks a small footer at the end of the staging area for a validated, "install pending" image. If one is pending, it copies it sector-by-sector into the app region, clears the pending flag, then chain-loads into the app (<code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">rom_chain_image()</code> on RP2350; a hand-rolled VTOR/SP/branch sequence, mirroring the community <code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">picowota</code> bootloader, on RP2040). If nothing is pending, it just chain-loads directly — adding negligible boot time.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Because <code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">install_pending</code> is only cleared <em>after</em> the copy fully completes, a power loss mid-copy is safe by design: the untouched staging-region source data is still there, and the bootloader just retries the copy from scratch on the next boot.</p><h3 style="color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">New REST endpoints</h3><ul style="padding-inline-start: 2em; color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">GET /rest/firmware_update_status</code><span> </span>— running firmware's version/VCS hash/build type, staged image's version/validity, and live upload progress</li><li><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">POST /rest/firmware_upload</code><span> </span>— accepts a<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">.bin</code><span> </span>upload, validates it (magic, CRC32, board type, size) as it's written to the staging region</li><li><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">GET /rest/firmware_install?i0=true</code><span> </span>— marks the validated staged image as pending install and reboots</li></ul><h3 style="color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">New web UI</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">A new <strong>Update Firmware</strong> page under the Settings drawer shows the currently-running firmware's Unique ID / Version / VCS Hash / Build Type, the staged image's version and validity, a file picker with an upload progress bar, and an <strong>Install</strong> button (enabled once a valid image is staged).</p><h2 style="color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">How to use</h2><h3 style="color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Updating a device already running this firmware</h3><ol style="padding-inline-start: 2em; color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Build for your board —<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">.\build_pico_w.ps1</code><span> </span>or<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">.\build_pico_2w.ps1</code><span> </span>— which produces<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">app_ota.bin</code><span> </span>alongside the usual<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">app.uf2</code><span> </span>(in<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">build_w\</code><span> </span>or<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">build\</code>).</li><li>In the web UI:<span> </span><strong>Settings → Update Firmware</strong>.</li><li>Choose<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">app_ota.bin</code><span> </span>under "Upload Firmware" and wait for the upload to finish.</li><li>Once "Staged Image Status" shows the image is valid, click<span> </span><strong>Install</strong>.</li><li>The device reboots; the bootloader copies the new image into place and boots into it automatically — no cable, no BOOTSEL.</li></ol><h3 style="color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">One-time migration from older (pre-OTA) firmware</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This PR changes the flash layout, so a device on older firmware needs a one-time <strong>two-step manual BOOTSEL flash</strong> to adopt it:</p><ol style="padding-inline-start: 2em; color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Hold BOOTSEL, connect via USB, drag<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">build_w\bootloader\bootloader.uf2</code><span> </span>(or<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">build\bootloader\bootloader.uf2</code><span> </span>for pico2_w) onto the<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">RPI-RP2</code><span> </span>drive.</li><li>Let it finish and the board reset/re-enter BOOTSEL.</li><li>Drag<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">build_w\app.uf2</code><span> </span>(or<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">build\app.uf2</code>) on as a second, separate step.</li></ol><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">After that, every future update goes through the web UI flow above — no more manual flashing.</p><h3 style="color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Safety / validation</h3><ul style="padding-inline-start: 2em; color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Every uploaded image is checked before it's trusted: magic number, footer CRC32, payload CRC32, board type (blocks flashing a<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">pico_w</code><span> </span>image onto a<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">pico2_w</code>, and vice versa), and size against the staging region's capacity.</li><li>The staging area is cleared at the start of every new upload and again after a successful install, so the UI never shows a stale "ready to install" image from a previous cycle.</li><li>The bootloader itself has no FreeRTOS, no networking, no display — a minimal, auditable dependency surface for the one piece of code that runs before everything else, every boot.</li></ul><h3 style="color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Known limitations</h3><ul style="padding-inline-start: 2em; color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>No automatic rollback if a bad image gets installed.</li><li>The bootloader is only ever updated via a manual BOOTSEL reflash — no bootloader self-update.</li><li>A single-file combined bootloader+app UF2 (to make the one-time migration a single drag-and-drop instead of two) was explored but repeatedly failed on real hardware in ways that weren't fully root-caused; the two-step migration above is the supported path.</li></ul><h3 style="color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Test plan</h3><ul class="contains-task-list" style="padding-inline-start: 2em; color: rgb(32, 32, 32); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(228, 229, 230); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Clean build both boards (<code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">pico_w</code>,<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">pico2_w</code>); confirm<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">bootloader.uf2</code>,<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">app.uf2</code>,<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">app_ota.bin</code><span> </span>all produced with no warnings</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(228, 229, 230); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Two-step BOOTSEL migration on a freshly-erased chip; confirm LCD and web interface both come up</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(228, 229, 230); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Upload<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">app_ota.bin</code><span> </span>through the web UI; confirm the Staged Image Version/Status populate correctly</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(228, 229, 230); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Click Install; confirm the device reboots and comes up running the new version (check Version/VCS Hash on the Update Firmware page)</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(228, 229, 230); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Confirm the staged image is cleared after a successful install</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(228, 229, 230); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Repeat on both<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">pico_w</code><span> </span>and<span> </span><code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">pico2_w</code></li></ul><!--EndFragment-->
</body>
</html>