### PR TITLE
Fix REST query parsing when parameter values contain ampersands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ _deps
 
 # Build directory
 build*/
+
+# Local ARM toolchain download
+.toolchain/

--- a/configure_env.sh
+++ b/configure_env.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Configure build environment for macOS/Linux.
+# Source this script before running cmake:
+#   source ./configure_env.sh
+
+set -euo pipefail
+
+if [[ -n "${BASH_SOURCE:-}" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+else
+    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+fi
+
+# Prefer the bundled ARM GNU toolchain (includes newlib).
+# Homebrew's arm-none-eabi-gcc alone is incomplete for Pico SDK builds.
+TOOLCHAIN_DIR="${SCRIPT_DIR}/.toolchain/arm-gnu-toolchain-14.2.rel1-darwin-arm64-arm-none-eabi"
+if [[ -d "${TOOLCHAIN_DIR}/bin" ]]; then
+    export PICO_TOOLCHAIN_PATH="${TOOLCHAIN_DIR}"
+    export PATH="${TOOLCHAIN_DIR}/bin:${PATH}"
+elif [[ -d "/Applications/ArmGNUToolchain" ]]; then
+    # Fallback: brew cask gcc-arm-embedded install location
+    ARM_TOOLCHAIN="$(find /Applications/ArmGNUToolchain -maxdepth 3 -type d -name bin | head -1 | xargs dirname)"
+    export PICO_TOOLCHAIN_PATH="${ARM_TOOLCHAIN}"
+    export PATH="${ARM_TOOLCHAIN}/bin:${PATH}"
+else
+    echo "Warning: No complete ARM toolchain found."
+    echo "Install one of:"
+    echo "  1) Run: ./setup_toolchain.sh"
+    echo "  2) brew install --cask gcc-arm-embedded"
+fi
+
+export PICO_SDK_PATH="${SCRIPT_DIR}/library/pico-sdk"
+
+echo "PICO_SDK_PATH=${PICO_SDK_PATH}"
+echo "PICO_TOOLCHAIN_PATH=${PICO_TOOLCHAIN_PATH:-not set}"
+echo "arm-none-eabi-gcc: $(command -v arm-none-eabi-gcc 2>/dev/null || echo 'not found')"

--- a/setup_toolchain.sh
+++ b/setup_toolchain.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Download and extract the ARM GNU toolchain for macOS (Apple Silicon).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOLCHAIN_ROOT="${SCRIPT_DIR}/.toolchain"
+ARCHIVE="${TOOLCHAIN_ROOT}/arm-gnu-toolchain.tar.xz"
+URL="https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-darwin-arm64-arm-none-eabi.tar.xz"
+EXTRACTED="${TOOLCHAIN_ROOT}/arm-gnu-toolchain-14.2.rel1-darwin-arm64-arm-none-eabi"
+
+mkdir -p "${TOOLCHAIN_ROOT}"
+
+if [[ -x "${EXTRACTED}/bin/arm-none-eabi-gcc" ]]; then
+    echo "Toolchain already installed at ${EXTRACTED}"
+    exit 0
+fi
+
+echo "Downloading ARM GNU Toolchain..."
+curl -L -o "${ARCHIVE}" "${URL}"
+echo "Extracting..."
+tar -xf "${ARCHIVE}" -C "${TOOLCHAIN_ROOT}"
+echo "Done. Source ./configure_env.sh before building."

--- a/src/http_rest.c
+++ b/src/http_rest.c
@@ -2844,31 +2844,74 @@ void decode_uri(char * dst, const char * src) {
     *dst++ = '\0';
 }
 
+static void decode_uri_inplace(char *str) {
+    char *dst = str;
+    const char *src = str;
+    char a, b;
+
+    while (*src) {
+        if ((*src == '%') &&
+            ((a = src[1]) && (b = src[2])) &&
+            (isxdigit(a) && isxdigit(b))) {
+                if (a >= 'a')
+                      a -= 'a'-'A';
+                if (a >= 'A')
+                      a -= ('A' - 10);
+                else
+                      a -= '0';
+                if (b >= 'a')
+                      b -= 'a'-'A';
+                if (b >= 'A')
+                      b -= ('A' - 10);
+                else
+                      b -= '0';
+                *dst++ = 16*a+b;
+                src+=3;
+        } else if (*src == '+') {
+            *dst++ = ' ';
+            src++;
+        } else {
+            *dst++ = *src++;
+        }
+    }
+    *dst = '\0';
+}
+
 
 static err_t http_find_file(struct http_state * hs, const char * uri, int is_09) {
     struct fs_file * file = NULL;
     char * params = NULL;
 
-    // The decoded URI will be fed to the parameter and REST handler loopup
-    // decoded_uri will be within the scope of `http_find_file` exclusively
-    char decoded_uri[strlen(uri) + 1];
-    memset(decoded_uri, 0x0, sizeof(decoded_uri));
-    decode_uri(decoded_uri, uri);
+    // Split path and query before decoding. Query values may contain encoded
+    // characters such as %26 (&). Decoding the full URI before splitting
+    // parameters would turn those into literal delimiters.
+    const char * query = strchr(uri, '?');
+    size_t path_len = query ? (size_t)(query - uri) : strlen(uri);
 
-    // First, isolate the base URI (without any parameters)
-    params = (char *) strchr(decoded_uri, '?');
-    if (params != NULL) {
-        // uri includes parameters, we need to terminate the base URI
-        *params = 0;
-        params += 1;
+    char path_copy[path_len + 1];
+    char decoded_path[path_len + 1];
+    memcpy(path_copy, uri, path_len);
+    path_copy[path_len] = '\0';
+    decode_uri(decoded_path, path_copy);
+
+    char params_buf[LWIP_HTTPD_MAX_REQUEST_URI_LEN];
+    if (query != NULL) {
+        strncpy(params_buf, query + 1, sizeof(params_buf) - 1);
+        params_buf[sizeof(params_buf) - 1] = '\0';
+        params = params_buf;
     }
 
     // Look for handler
-    rest_handler_t rest_handler = rest_get_handler(decoded_uri);
+    rest_handler_t rest_handler = rest_get_handler(decoded_path);
 
     if (rest_handler) {
-        // Extract parameters from the uri
+        // Extract parameters from the still-encoded query string
         http_cgi_paramcount = extract_uri_parameters(hs, params);
+        for (int i = 0; i < http_cgi_paramcount; i++) {
+            if (http_cgi_param_vals[i] != NULL) {
+                decode_uri_inplace(http_cgi_param_vals[i]);
+            }
+        }
 
         rest_handler(&hs->file_handle, http_cgi_paramcount, hs->params, hs->param_vals);
         file = &hs->file_handle;


### PR DESCRIPTION
## Summary
- Fix Wi-Fi SSID and password settings when values contain `&` or other URL-encoded characters
- Decode the REST request path and query string separately so `%26` is not expanded before query parameters are split
- Add macOS build helper scripts (`configure_env.sh`, `setup_toolchain.sh`) and ignore local toolchain downloads

## Problem
The web UI submits settings via GET requests such as `/rest/wireless_config?w0=My%26Network&...`. The server previously decoded the entire URI before splitting query parameters, so `%26` became `&` and the SSID was truncated at the first ampersand.

## Test plan
- [ ] Build firmware for target board (`pico_w` or `pico2_w`)
- [ ] Configure Wi-Fi from the web portal with an SSID containing `&`
- [ ] Save to EEPROM and reboot
- [ ] Verify the device connects using the full SSID
- [ ] Verify passwords containing `&`, `+`, or `=` are also preserved